### PR TITLE
Update README.md

### DIFF
--- a/tools/PTE/README.md
+++ b/tools/PTE/README.md
@@ -87,7 +87,7 @@ If planning to run your Fabric network locally, you'll need docker and a bit mor
 You need to install a gnu-compatible version of the `awk`, `date` utility. Install Brew (http://brew.sh) and run the following commands:
 ```
 brew install gawk --with-default-names
-brew install gdate --with-default-names
+brew install coreutils
 ```
 
 ## Setup


### PR DESCRIPTION
brew install gdate --with-default-names command fails with below errors in Mac Darwin. gdate can be installed with ```brew install coreutils``` Updating README.md accordingly.

nileshs-mbp:PTE nileshdeotale$ uname -a
Darwin nileshs-mbp.raleigh.ibm.com 17.5.0 Darwin Kernel Version 17.5.0: Mon Mar  5 22:24:32 PST 2018; root:xnu-4570.51.1~1/RELEASE_X86_64 x86_64

brew install gdate --with-default-names
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 2 taps (homebrew/core, homebrew/cask).
==> Updated Formulae
azure-cli

Error: No available formula with the name "gdate" 
==> Searching for a previously deleted formula (in the last month)...
Warning: homebrew/core is shallow clone. To get complete history run:
  git -C "$(brew --repo homebrew/core)" fetch --unshallow

Error: No previously deleted formula found.
==> Searching for similarly named formulae...
==> Searching local taps...
Error: No similarly named formulae found.
==> Searching taps...
==> Searching taps on GitHub...
Error: No formulae found in taps.

 This is my commit message

Signed-off-by: Nilesh-Deotale