### PR TITLE
Refactor: Decoupled Chaincode Logic from PTE Execution Engine

### DIFF
--- a/tools/PTE/README.md
+++ b/tools/PTE/README.md
@@ -71,8 +71,9 @@ In brief, PTE has the following features:
 ## Prerequisites
 To build and test the following prerequisites must be installed first:
 
-- node and npm lts/boron release (v6.10.x and v3.10.x)
-    -  node v7 is not currently supported
+- node and npm
+    - `node`: >=`v8.9.4` AND <`v9.0`
+    - `npm`: >=`v5.6.0` AND <`v6.0`
 - gulp command
     - `npm install -g gulp`
 - go (v1.7 or later)

--- a/tools/PTE/ccArgumentsGenerators/ccFunctionsBase.js
+++ b/tools/PTE/ccArgumentsGenerators/ccFunctionsBase.js
@@ -1,0 +1,40 @@
+class ccFunctionsBase {
+	constructor(ccDfnPtr, logger, Nid, channelName, org, pid) {
+		this.ccDfnPtr = ccDfnPtr;
+		this.logger = logger;
+		this.Nid = Nid;
+		this.channelName = channelName;
+		this.org = org;
+		this.pid = pid;
+		this.keyStart = 0;
+		this.payLoadMin = 0;
+		this.payLoadMax = 0;
+		this.payLoadType = 'RANDOM';
+		this.arg0 = 0;
+		var i = 0;
+		this.keyIdx = [];
+		if (typeof( this.ccDfnPtr.ccOpt.keyIdx ) !== 'undefined') {
+			for (i=0; i<this.ccDfnPtr.ccOpt.keyIdx.length; i++) {
+				this.keyIdx.push(this.ccDfnPtr.ccOpt.keyIdx[i]);
+			}
+		}
+		logger.info('[Nid:chan:org:id=%d:%s:%s:%d pte-execRequest] keyIdx: ', this.Nid, this.channelName, this.org, this.pid, this.keyIdx);
+		this.testInvokeArgs = [];
+		for (i=0; i<this.ccDfnPtr.invoke.move.args.length; i++) {
+			this.testInvokeArgs.push(this.ccDfnPtr.invoke.move.args[i]);
+		}
+		this.testQueryArgs = [];
+		for (i=0; i<this.ccDfnPtr.invoke.query.args.length; i++) {
+			this.testQueryArgs.push(this.ccDfnPtr.invoke.query.args[i]);
+		}
+		this.keyPayLoad = [];
+		if (typeof( this.ccDfnPtr.ccOpt.keyPayLoad ) !== 'undefined') {
+			for (i=0; i<this.ccDfnPtr.ccOpt.keyPayLoad.length; i++) {
+				this.keyPayLoad.push(this.ccDfnPtr.ccOpt.keyPayLoad[i]);
+			}
+		}
+		this.logger.info('[Nid:chan:org:id=%d:%s:%s:%d pte-execRequest] keyPayLoad: ', this.Nid, this.channelName, this.org, this.pid, this.keyPayLoad);
+	}
+}
+
+module.exports = ccFunctionsBase;

--- a/tools/PTE/ccArgumentsGenerators/ccchecker/ccFunctions.js
+++ b/tools/PTE/ccArgumentsGenerators/ccchecker/ccFunctions.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2016 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * Licensed Materials - Property of IBM
+ * © Copyright IBM Corp. 2016
+ */
+
+const crypto = require('crypto');
+const ccFunctionsBase = require('../ccFunctionsBase.js');
+
+class ccFunctions extends ccFunctionsBase {
+	constructor(ccDfnPtr, logger, Nid, channelName, org, pid) {
+		super(ccDfnPtr, logger, Nid, channelName, org, pid);
+		this.keyStart = parseInt(this.ccDfnPtr.ccOpt.keyStart);
+		this.payLoadMin = parseInt(this.ccDfnPtr.ccOpt.payLoadMin)/2;
+		this.payLoadMax = parseInt(this.ccDfnPtr.ccOpt.payLoadMax)/2;
+		if ( this.ccDfnPtr.ccOpt.payLoadType )
+			this.payLoadType = this.ccDfnPtr.ccOpt.payLoadType.toUpperCase();
+		this.arg0 = parseInt(this.keyStart);
+		this.logger.info('[Nid:chan:org:id=%d:%s:%s:%d pte-execRequest] %s chaincode setting: keyStart=%d payLoadMin=%d payLoadMax=%d',
+				this.Nid, this.channelName, this.org, this.pid, this.ccDfnPtr.ccType, this.keyStart, 
+				parseInt(this.ccDfnPtr.ccOpt.payLoadMin), parseInt(this.ccDfnPtr.ccOpt.payLoadMax));
+	}
+
+	getInvokeArgs(txIDVar) {
+		this.arg0 ++;
+		var i = 0;
+		for ( i=0; i<this.keyIdx.length; i++ ) {
+			this.testInvokeArgs[this.keyIdx[i]] = 'key_'+txIDVar+'_'+this.arg0;
+		}
+
+		// randomise length of payload
+		var rlen = Math.floor(Math.random() * (this.payLoadMax - this.payLoadMin)) + this.payLoadMin;
+
+		if ( this.payLoadType == 'RANDOM' ) {
+			var buf = crypto.randomBytes(rlen);
+			for ( i = 0; i < this.keyPayLoad.length; i++ ) {
+				this.testInvokeArgs[this.keyPayLoad[i]] = buf.toString('hex');
+			}
+		}
+	}
+
+	getQueryArgs(txIDVar) {
+		this.arg0 ++;
+		var i = 0;
+		for ( i=0; i<this.keyIdx.length; i++ ) {
+			this.testQueryArgs[this.keyIdx[i]] = 'key_'+txIDVar+'_'+this.arg0;
+		}
+	}
+
+	getExecModeLatencyFreq() {
+		return 0;
+	}
+
+	getExecModeSimpleFreq() {
+		return 0;
+	}
+
+	getExecModeProposalFreq() {
+		return 0;
+	}
+}
+
+module.exports = ccFunctions;

--- a/tools/PTE/ccArgumentsGenerators/marblescc/ccFunctions.js
+++ b/tools/PTE/ccArgumentsGenerators/marblescc/ccFunctions.js
@@ -1,0 +1,164 @@
+/**
+ * Copyright 2016 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * Licensed Materials - Property of IBM
+ * © Copyright IBM Corp. 2016
+ */
+
+const ccFunctionsBase = require('../ccFunctionsBase.js');
+
+class ccFunctions extends ccFunctionsBase {
+	constructor(ccDfnPtr, logger, Nid, channelName, org, pid) {
+		super(ccDfnPtr, logger, Nid, channelName, org, pid);
+		this.moveMarbleOwner = 'tom';
+		this.moveMarbleName = 'marble';
+		this.queryMarbleOwner = 'tom';
+		this.queryMarbleName = 'marble';
+		this.nOwner = 100;
+		this.queryMarbleDocType = 'marble';
+	    this.keyStart = parseInt(this.ccDfnPtr.ccOpt.keyStart);
+    	this.payLoadMin = parseInt(this.ccDfnPtr.ccOpt.payLoadMin);
+    	this.payLoadMax = parseInt(this.ccDfnPtr.ccOpt.payLoadMax);
+    	this.arg0 = parseInt(this.keyStart);
+    	this.logger.info('[Nid:chan:org:id=%d:%s:%s:%d pte-execRequest] %s chaincode setting: keyStart=%d payLoadMin=%d payLoadMax=%d',
+                 this.Nid, this.channelName, this.org, this.pid, this.ccDfnPtr.ccType, this.keyStart, 
+				 parseInt(this.ccDfnPtr.ccOpt.payLoadMin), parseInt(this.ccDfnPtr.ccOpt.payLoadMax));
+
+    	// get number of owners
+    	if ( typeof( this.ccDfnPtr.invoke.nOwner ) !== 'undefined'  ) {
+        	this.nOwner=parseInt(this.ccDfnPtr.invoke.nOwner);
+    	}
+
+    	// get prefix owner name
+    	// moveMarbleOwner
+    	// "args": ["marble", "blue","35","tom"]
+    	if ( this.ccDfnPtr.invoke.move.fcn == 'initMarble' ) {
+        	this.moveMarbleOwner = this.ccDfnPtr.invoke.move.args[3];
+    	}
+    	this.moveMarbleName=ccDfnPtr.invoke.move.args[0];
+
+    	// queryMarbleByOwner
+    	// "args": ["tom"]
+    	//
+    	// queryMarble
+    	// "args": {
+    	//     "selector": {
+    	//         "owner":"tom",
+    	//         "docType":"marble",
+    	//         "color":"blue",
+    	//         "size":"35",
+    	//     }
+    	// }
+    	if ( this.ccDfnPtr.invoke.query.fcn == 'queryMarblesByOwner' ) {
+        	this.queryMarbleOwner=ccDfnPtr.invoke.query.args[0];
+    	} else if ( this.ccDfnPtr.invoke.query.fcn == 'queryMarbles' ) {
+        	if ( typeof( this.ccDfnPtr.invoke.query.args.selector.owner ) !== 'undefined' ) {
+            	this.queryMarbleOwner=this.ccDfnPtr.invoke.query.args.selector.owner;
+        	}
+        	if ( typeof( this.ccDfnPtr.invoke.query.args.selector.docType ) !== 'undefined' ) {
+            	this.queryMarbleDocType=this.ccDfnPtr.invoke.query.args.selector.docType;
+        	}
+    	}
+    	this.queryMarbleName=this.ccDfnPtr.invoke.query.args[0];
+
+		this.rqSelector = {};
+		if ( this.ccDfnPtr.invoke.query.fcn == 'queryMarbles' ) {
+			if ( typeof( this.ccDfnPtr.invoke.query.args.selector ) !== 'undefined' ) {
+				this.rqSelector = this.ccDfnPtr.invoke.query.args.selector;
+			}
+		}
+	}
+
+	getInvokeArgs(txIDVar) {
+		this.arg0 ++;
+		var i = 0;
+		for ( i=0; i<this.keyIdx.length; i++ ) {
+			this.testInvokeArgs[this.keyIdx[i]] = this.moveMarbleName+'_'+txIDVar+'_'+this.arg0;
+		}
+		var index=this.arg0%this.nOwner;
+		if ( this.ccDfnPtr.invoke.move.fcn == 'initMarble' ) {
+			this.testInvokeArgs[3]=this.moveMarbleOwner+'_'+txIDVar+'_'+index;
+		}
+		// marble size
+		for ( i=0; i<this.keyPayLoad.length; i++ ) {
+			this.testInvokeArgs[this.keyPayLoad[i]] = String(index);
+		}
+	}
+
+	getQueryArgs(txIDVar) {
+        this.arg0 ++;
+        var keyA = this.keyStart;
+        if ( this.arg0 - this.keyStart > 10 ) {
+            this.keyA = this.arg0 - 10;
+        }
+        if ( this.ccDfnPtr.invoke.query.fcn == 'getMarblesByRange' ) {
+            this.testQueryArgs[0] = this.queryMarbleName+'_'+txIDVar+'_'+keyA;
+            this.testQueryArgs[1] = this.queryMarbleName+'_'+txIDVar+'_'+this.arg0;
+        } else if ( this.ccDfnPtr.invoke.query.fcn == 'queryMarblesByOwner' ) {
+            // marbles02 rich query: queryMarblesByOwner
+            var index=this.arg0%this.nOwner;
+            this.testQueryArgs[0] = this.queryMarbleOwner+'_'+txIDVar+'_'+index;
+        } else if ( this.ccDfnPtr.invoke.query.fcn == 'queryMarbles' ) {
+            // marbles02 rich query: queryMarbles
+            var selector=0;
+            var index=this.arg0%this.nOwner;
+            if ( this.rqSelector ) {
+                this.testQueryArgs[0]='{\"selector\":{';
+                for ( let key in this.rqSelector ) {
+                    if ( selector == 1 ) {
+                        this.testQueryArgs[0]=this.testQueryArgs[0]+',';
+                    }
+
+                    if ( key == 'owner' ) {
+                        this.testQueryArgs[0]=this.testQueryArgs[0]+'\"'+key+'\":\"'+this.queryMarbleOwner+'_'+txIDVar+'_'+index+'\"';
+                    } else if ( key == 'size' ) {
+                        var mSize=this.arg0%this.nOwner;
+                        this.testQueryArgs[0]=this.testQueryArgs[0]+'\"'+key+'\":'+mSize;
+                    } else {
+                        this.testQueryArgs[0]=this.testQueryArgs[0]+'\"'+key+'\":\"'+this.rqSelector[key]+'\"';
+                    }
+
+                    if ( selector == 0 ) {
+                        selector = 1;
+                    }
+                }
+                this.testQueryArgs[0]=this.testQueryArgs[0]+'}';
+            }
+
+            this.testQueryArgs[0]=this.testQueryArgs[0]+'}';
+
+        } else {
+			var i = 0;
+            for ( i=0; i<this.keyIdx.length; i++ ) {
+                this.testQueryArgs[this.keyIdx[i]] = this.queryMarbleName+'_'+txIDVar+'_'+this.arg0;
+            }
+        }
+	}
+
+	getExecModeLatencyFreq() {
+		return 20000;
+	}
+
+	getExecModeSimpleFreq() {
+		return 20000;
+	}
+
+	getExecModeProposalFreq() {
+		return 20000;
+	}
+}
+
+module.exports = ccFunctions;

--- a/tools/PTE/ccArgumentsGenerators/marblescc_priv/ccFunctions.js
+++ b/tools/PTE/ccArgumentsGenerators/marblescc_priv/ccFunctions.js
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2016 IBM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * Licensed Materials - Property of IBM
+ * © Copyright IBM Corp. 2016
+ */
+
+const ccFunctionsBase = require('../ccFunctionsBase.js');
+
+class ccFunctions extends ccFunctionsBase {
+	constructor(ccDfnPtr, logger, Nid, channelName, org, pid) {
+		super(ccDfnPtr, logger, Nid, channelName, org, pid);
+		this.moveMarbleOwner = 'tom';
+		this.moveMarbleName = 'marble';
+		this.queryMarbleOwner = 'tom';
+		this.queryMarbleName = 'marble';
+		this.nOwner = 100;
+		this.queryMarbleDocType = 'marble';
+	    this.keyStart = parseInt(this.ccDfnPtr.ccOpt.keyStart);
+    	this.payLoadMin = parseInt(this.ccDfnPtr.ccOpt.payLoadMin);
+    	this.payLoadMax = parseInt(this.ccDfnPtr.ccOpt.payLoadMax);
+    	this.arg0 = parseInt(this.keyStart);
+    	this.logger.info('[Nid:chan:org:id=%d:%s:%s:%d pte-execRequest] %s chaincode setting: keyStart=%d payLoadMin=%d payLoadMax=%d',
+                 this.Nid, this.channelName, this.org, this.pid, this.ccDfnPtr.ccType, this.keyStart, 
+				 parseInt(this.ccDfnPtr.ccOpt.payLoadMin), parseInt(this.ccDfnPtr.ccOpt.payLoadMax));
+
+    	// get number of owners
+    	if ( typeof( this.ccDfnPtr.invoke.nOwner ) !== 'undefined'  ) {
+        	this.nOwner=parseInt(this.ccDfnPtr.invoke.nOwner);
+    	}
+
+    	// get prefix owner name
+    	// moveMarbleOwner
+    	// "args": ["marble", "blue","35","tom"]
+    	if ( this.ccDfnPtr.invoke.move.fcn == 'initMarble' ) {
+        	this.moveMarbleOwner = this.ccDfnPtr.invoke.move.args[3];
+    	}
+    	this.moveMarbleName=ccDfnPtr.invoke.move.args[0];
+
+    	// queryMarbleByOwner
+    	// "args": ["tom"]
+    	//
+    	// queryMarble
+    	// "args": {
+    	//     "selector": {
+    	//         "owner":"tom",
+    	//         "docType":"marble",
+    	//         "color":"blue",
+    	//         "size":"35",
+    	//     }
+    	// }
+    	if ( this.ccDfnPtr.invoke.query.fcn == 'queryMarblesByOwner' ) {
+        	this.queryMarbleOwner=ccDfnPtr.invoke.query.args[0];
+    	} else if ( this.ccDfnPtr.invoke.query.fcn == 'queryMarbles' ) {
+        	if ( typeof( this.ccDfnPtr.invoke.query.args.selector.owner ) !== 'undefined' ) {
+            	this.queryMarbleOwner=this.ccDfnPtr.invoke.query.args.selector.owner;
+        	}
+        	if ( typeof( this.ccDfnPtr.invoke.query.args.selector.docType ) !== 'undefined' ) {
+            	this.queryMarbleDocType=this.ccDfnPtr.invoke.query.args.selector.docType;
+        	}
+    	}
+    	this.queryMarbleName=this.ccDfnPtr.invoke.query.args[0];
+	}
+
+	getInvokeArgs(txIDVar) {
+		this.arg0 ++;
+		var i = 0;
+		for ( i=0; i<this.keyIdx.length; i++ ) {
+			this.testInvokeArgs[this.keyIdx[i]] = this.moveMarbleName+'_'+txIDVar+'_'+this.arg0;
+		}
+		var index=this.arg0%this.nOwner;
+		if ( this.ccDfnPtr.invoke.move.fcn == 'initMarble' ) {
+			this.testInvokeArgs[3]=this.moveMarbleOwner+'_'+txIDVar+'_'+this.index;
+		}
+		// marble size
+		for ( i=0; i<this.keyPayLoad.length; i++ ) {
+			this.testInvokeArgs[this.keyPayLoad[i]] = String(index);
+		}
+	}
+
+	getQueryArgs(txIDVar) {
+        this.arg0 ++;
+		var i = 0;
+        var keyA = this.keyStart;
+        if ( this.arg0 - this.keyStart > 10 ) {
+            keyA = this.arg0 - 10;
+        }
+        if ( this.ccDfnPtr.invoke.query.fcn == 'readMarblePrivateDetails' ) {
+            for ( i=0; i<this.keyIdx.length; i++ ) {
+                this.testQueryArgs[this.keyIdx[i]] = this.queryMarbleName+'_'+txIDVar+'_'+this.arg0;
+            }
+        } else {
+            for ( i=0; i<this.keyIdx.length; i++ ) {
+                this.testQueryArgs[this.keyIdx[i]] = this.queryMarbleName+'_'+txIDVar+'_'+this.arg0;
+            }
+        }
+	}
+
+	getExecModeLatencyFreq() {
+		return 20000;
+	}
+
+	getExecModeSimpleFreq() {
+		return 20000;
+	}
+
+	getExecModeProposalFreq() {
+		return 20000;
+	}
+}
+
+module.exports = ccFunctions;

--- a/tools/PTE/pte-execRequest.js
+++ b/tools/PTE/pte-execRequest.js
@@ -1354,7 +1354,7 @@ function execModeLatency() {
         }
         logger.info('[Nid:chan:org:id=%d:%s:%s:%d execModeLatency] tStart %d, tLocal %d', Nid, channelName, org, pid, tStart, tLocal);
         if ( invokeType == 'MOVE' ) {
-			var freq = ccFuncInst.getExecModeLatencyFreq();
+            var freq = ccFuncInst.getExecModeLatencyFreq();
 
             if (evtType == 'FILTEREDBLOCK') {
                 eventRegisterFilteredBlock();
@@ -1461,7 +1461,7 @@ function execModeSimple() {
         }
         logger.info('[Nid:chan:org:id=%d:%s:%s:%d execModeSimple] tStart %d, tLocal %d', Nid, channelName, org, pid, tStart, tLocal);
         if ( invokeType == 'MOVE' ) {
-			var freq = ccFuncInst.getExecModeSimpleFreq();
+            var freq = ccFuncInst.getExecModeSimpleFreq();
             invoke_move_simple(freq);
         } else if ( invokeType == 'QUERY' ) {
             invoke_query_simple(0);
@@ -2033,7 +2033,7 @@ function execModeProposal() {
         }
         logger.info('[Nid:chan:org:id=%d:%s:%s:%d execModeProposal] tStart %d, tLocal %d', Nid, channelName, org, pid, tStart, tLocal);
         if ( invokeType == 'MOVE' ) {
-			var freq = ccFuncInst.getExecModeProposalFreq();
+            var freq = ccFuncInst.getExecModeProposalFreq();
             invoke_move_proposal();
         } else if ( invokeType == 'QUERY' ) {
             logger.error('[Nid:chan:org:id=%d:%s:%s:%d execModeProposal] invalid invokeType= %s', Nid, channelName, org, pid, invokeType);


### PR DESCRIPTION
Removed chaincode-specific logic to generate arguments from `pte-execRequest.js`. That logic is now in folders under `ccArgumentsGenerators`, with the subfolder name corresponding to a `ccType`.