### PR TITLE
Fix CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Fabric Test Maintainers
-:*	@bmos299 @christo4ferris @denyeart @dongmingh @lhaskins @mastersingh24 @scottz64 @adnan-c
+*	@bmos299 @christo4ferris @denyeart @dongmingh @lhaskins @mastersingh24 @scottz64 @adnan-c


### PR DESCRIPTION
There is a stray colon at the beginning of the file preventing matching

Signed-off-by: Brett Logan <Brett.T.Logan@ibm.com>