### PR TITLE
[FAB-17103] Add upgrade network option to operator

### DIFF
--- a/regression/smoke/runSmokeTestSuite.sh
+++ b/regression/smoke/runSmokeTestSuite.sh
@@ -27,7 +27,15 @@ fi
 
 echo "======== Smoke Test Suite using ginkgo and operator tools ========"
 cd $SMOKEDIR && ginkgo -v
+StatusOperator=$?
+
 echo "======== Performance Test using PTE and NL tools ========"
 cd $SMOKEDIR/../daily && ginkgo --focus test_FAB7929_8i
-echo "------> Smoke tests completed"
+StatusPteNL=$?
 
+if [ $StatusOperator == 0 ] && [ $StatusPteNL == 0 ]; then
+    echo "------> Smoke tests completed"
+else
+    echo "------> Smoke tests failed with above errors"
+    exit 1
+fi

--- a/tools/operator/launcher/k8s/network.go
+++ b/tools/operator/launcher/k8s/network.go
@@ -57,10 +57,10 @@ func (k K8s) ConfigMapsNSecretsArgs(componentName, k8sType string) []string {
 }
 
 //GenerateConfigurationFiles - to generate all the configuration files
-func (k K8s) GenerateConfigurationFiles() error {
+func (k K8s) GenerateConfigurationFiles(upgrade bool) error {
 
 	network := nl.Network{TemplatesDir: paths.TemplateFilePath("k8s")}
-	err := network.GenerateConfigurationFiles()
+	err := network.GenerateConfigurationFiles(upgrade)
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func (k K8s) K8sNetwork(action string) error {
 	var network nl.Network
 	switch action {
 	case "up":
-		err = k.GenerateConfigurationFiles()
+		err = k.GenerateConfigurationFiles(false)
 		if err != nil {
 			logger.ERROR("Failed to generate k8s configuration files")
 			return err

--- a/tools/operator/launcher/nl/network.go
+++ b/tools/operator/launcher/nl/network.go
@@ -39,7 +39,7 @@ func (n Network) GetConfigData(networkSpecPath string) (networkspec.Config, erro
 }
 
 //GenerateConfigurationFiles - to generate all the configuration files
-func (n Network) GenerateConfigurationFiles() error {
+func (n Network) GenerateConfigurationFiles(upgrade bool) error {
 
 	configtxPath := paths.TemplateFilePath("configtx")
 	cryptoConfigPath := paths.TemplateFilePath("crypto-config")
@@ -47,6 +47,9 @@ func (n Network) GenerateConfigurationFiles() error {
 	configFilesPath := fmt.Sprintf("--output=%s", paths.ConfigFilesDir())
 	yttPath := fmt.Sprintf("%s/ytt", paths.YTTPath())
 	inputArgs := []string{configtxPath, cryptoConfigPath, n.TemplatesDir}
+	if upgrade {
+		inputArgs = []string{n.TemplatesDir}
+	}
 	yttObject := ytt.YTT{InputPath: inputFilePath, OutputPath: configFilesPath}
 	_, err := networkclient.ExecuteCommand(yttPath, yttObject.Args(inputArgs), true)
 	if err != nil {

--- a/tools/operator/main.go
+++ b/tools/operator/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"io/ioutil"
+	"fmt"
 
 	"github.com/hyperledger/fabric-test/tools/operator/networkclient"
 	"github.com/hyperledger/fabric-test/tools/operator/launcher/dockercompose"
@@ -44,7 +45,7 @@ func doAction(action, env, kubeConfigPath, inputFilePath string) error {
 	var err error
 	var inputPath string
 	var config networkspec.Config
-	actions := []string{"up", "down", "createChannelTxn", "migrate", "health"}
+	actions := []string{"up", "down", "createChannelTxn", "migrate", "health", "upgradeNetwork"}
 	if contains(actions, action) {
 		contents, _ := ioutil.ReadFile(inputFilePath)
 		contents = append([]byte("#@data/values \n"), contents...)
@@ -72,12 +73,12 @@ func doAction(action, env, kubeConfigPath, inputFilePath string) error {
 			logger.ERROR("Failed to delete network")
 			return err
 		}
-	// case "upgradeNetwork":
-	// 	err = launcher.Launcher("upgradeNetwork", env, kubeConfigPath, inputPath)
-	// 	if err != nil {
-	// 		logger.ERROR("Failed to upgrade network")
-	// 		return err
-	// 	}
+	case "upgradeNetwork":
+		err = launcher.Launcher("upgradeNetwork", env, kubeConfigPath, inputPath)
+		if err != nil {
+			logger.ERROR("Failed to upgrade network")
+			return err
+		}
 	case "create":
 		err = testclient.Testclient("create", inputFilePath)
 		if err != nil {
@@ -153,7 +154,7 @@ func doAction(action, env, kubeConfigPath, inputFilePath string) error {
 			return err
 		}
 	default:
-		logger.ERROR("Incorrect action ", action ," . Use up or down or create or join or anchorpeer or install or instantiate or upgrade or invoke or query or createChannelTxn or migrate or health for action ", action)
+		logger.ERROR("Incorrect action ", action ," provided. Use up or down or create or join or anchorpeer or install or instantiate or upgrade or invoke or query or createChannelTxn or migrate or health or upgradeNetwork for action ")
 		return err
 	}
 	return nil
@@ -169,5 +170,8 @@ func main()  {
 		env = "k8s"
 	}
 
-	doAction(*action, env, *kubeConfigPath, *inputFilePath)
+	err := doAction(*action, env, *kubeConfigPath, *inputFilePath)
+	if err != nil {
+		logger.ERROR(fmt.Sprintln("Operator failed with error ", err))
+	}
 }

--- a/tools/operator/networkclient/upgradeNetwork.go
+++ b/tools/operator/networkclient/upgradeNetwork.go
@@ -1,0 +1,152 @@
+package networkclient
+
+import (
+	"fmt"
+
+	"github.com/hyperledger/fabric-test/tools/operator/logger"
+	"github.com/hyperledger/fabric-test/tools/operator/networkspec"
+)
+
+//UpgradeDB -  to upgrade db
+func UpgradeDB(config networkspec.Config, kubeConfigPath string) error {
+
+	for i := 0; i < len(config.PeerOrganizations); i++ {
+		for j := 0; j < config.PeerOrganizations[i].NumPeers; j++ {
+			args := []string{"upgradeDB",
+					config.PeerOrganizations[i].MSPID,
+					fmt.Sprintf("peer%d-%s", j, config.PeerOrganizations[i].Name),
+					fmt.Sprintf("%s", config.PeerOrganizations[i].Name),
+					config.ArtifactsLocation}
+			_, err := ExecuteCommand("./scripts/upgradeNetwork.sh", args, true)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	logger.INFO("Successfully updated dbs for all peers")
+	return nil
+}
+
+//UpdateCapability -  to update capability
+func UpdateCapability(config networkspec.Config, kubeConfigPath string) error {
+	capabilityGroup := "channel"
+	capabilityKey := getKeyFromCapability(config.ChannelCapabilities)
+	args := []string{"configUpdate",
+			config.OrdererOrganizations[0].MSPID,
+			fmt.Sprintf("orderer0-%s", config.OrdererOrganizations[0].Name),
+			fmt.Sprintf("%s", config.OrdererOrganizations[0].Name),
+			config.ArtifactsLocation,
+			fmt.Sprintf("%d", config.NumChannels),
+			capabilityKey,
+			capabilityGroup,
+			config.PeerOrganizations[0].MSPID,
+			config.PeerOrganizations[0].Name}
+	_, err := ExecuteCommand("./scripts/upgradeNetwork.sh", args, true)
+	if err != nil {
+		return err
+	}
+
+	capabilityGroup = "orderer"
+	capabilityKey = getKeyFromCapability(config.OrdererCapabilities)
+	args = []string{"configUpdate",
+			config.OrdererOrganizations[0].MSPID,
+			fmt.Sprintf("orderer0-%s", config.OrdererOrganizations[0].Name),
+			fmt.Sprintf("%s", config.OrdererOrganizations[0].Name),
+			config.ArtifactsLocation, fmt.Sprintf("0"),
+			capabilityKey,
+			capabilityGroup,
+			config.PeerOrganizations[0].MSPID,
+			config.PeerOrganizations[0].Name}
+	_, err = ExecuteCommand("./scripts/upgradeNetwork.sh", args, true)
+	if err != nil {
+		return err
+	}
+
+	capabilityGroup = "application"
+	capabilityKey = getKeyFromCapability(config.ApplicationCapabilities)
+	args = []string{"configUpdate",
+			config.OrdererOrganizations[0].MSPID,
+			fmt.Sprintf("orderer0-%s", config.OrdererOrganizations[0].Name),
+			fmt.Sprintf("%s", config.OrdererOrganizations[0].Name),
+			config.ArtifactsLocation,
+			fmt.Sprintf("%d", config.NumChannels),
+			capabilityKey,
+			capabilityGroup,
+			config.PeerOrganizations[0].MSPID,
+			config.PeerOrganizations[0].Name}
+	_, err = ExecuteCommand("./scripts/upgradeNetwork.sh", args, true)
+	if err != nil {
+		return err
+	}
+
+	logger.INFO("Successfully updated capabilities")
+	return nil
+}
+
+//UpdatePolicy - to update policy
+func UpdatePolicy(config networkspec.Config, kubeConfigPath string) error {
+	for j := 0; j < len(config.PeerOrganizations); j++ {
+		policyGroup := "consortium"
+		args := []string{"configUpdate",
+				config.OrdererOrganizations[0].MSPID,
+				fmt.Sprintf("orderer0-%s", config.OrdererOrganizations[0].Name),
+				fmt.Sprintf("%s", config.OrdererOrganizations[0].Name),
+				config.ArtifactsLocation,
+				fmt.Sprintf("0"),
+				fmt.Sprintf("null"),
+				policyGroup,
+				config.PeerOrganizations[j].MSPID,
+				config.PeerOrganizations[j].Name}
+		_, err := ExecuteCommand("./scripts/upgradeNetwork.sh", args, true)
+		if err != nil {
+			return err
+		}
+	}
+
+	for j := 0; j < len(config.PeerOrganizations); j++ {
+		policyGroup := "organization"
+		args := []string{"configUpdate",
+				config.OrdererOrganizations[0].MSPID,
+				fmt.Sprintf("orderer0-%s", config.OrdererOrganizations[0].Name),
+				fmt.Sprintf("%s", config.OrdererOrganizations[0].Name),
+				config.ArtifactsLocation,
+				fmt.Sprintf("%d", config.NumChannels),
+				fmt.Sprintf("null"),
+				policyGroup,
+				config.PeerOrganizations[j].MSPID,
+				config.PeerOrganizations[j].Name}
+		_, err := ExecuteCommand("./scripts/upgradeNetwork.sh", args, true)
+		if err != nil {
+			return err
+		}
+	}
+
+	policyGroups := []string{"apppolicy", "acls"}
+	for _, policyGroup := range(policyGroups){
+		args := []string{"configUpdate",
+				config.OrdererOrganizations[0].MSPID,
+				fmt.Sprintf("orderer0-%s", config.OrdererOrganizations[0].Name),
+				fmt.Sprintf("%s", config.OrdererOrganizations[0].Name),
+				config.ArtifactsLocation,
+				fmt.Sprintf("%d", config.NumChannels),
+				fmt.Sprintf("null"),
+				policyGroup,
+				config.PeerOrganizations[0].MSPID,
+				config.PeerOrganizations[0].Name}
+		_, err := ExecuteCommand("./scripts/upgradeNetwork.sh", args, true)
+		if err != nil {
+			return err
+		}
+	}
+
+	logger.INFO("Successfully updated policies")
+	return nil
+}
+
+func getKeyFromCapability(config map[string]string) string {
+	var key string
+	for key = range config {
+		return key
+	}
+	return key
+}

--- a/tools/operator/networkspec/structs.go
+++ b/tools/operator/networkspec/structs.go
@@ -11,10 +11,13 @@ type Config struct {
 	Orderer              struct {
 		OrdererType string `yaml:"ordererType,omitempty"`
 	} `yaml:"orderer,omitempty"`
-	NumChannels   int    `yaml:"numChannels,omitempty"`
-	TLS           string `yaml:"tls,omitempty"`
-	EnableNodeOUs bool   `yaml:"enableNodeOUs,omitempty"`
-	K8s           struct {
+	NumChannels             int               `yaml:"numChannels,omitempty"`
+	TLS                     string            `yaml:"tls,omitempty"`
+	EnableNodeOUs           bool              `yaml:"enableNodeOUs,omitempty"`
+	OrdererCapabilities     map[string]string `yaml:"ordererCapabilities,omitempty"`
+	ChannelCapabilities     map[string]string `yaml:"channelCapabilities,omitempty"`
+	ApplicationCapabilities map[string]string `yaml:"applicationCapabilities,omitempty"`
+	K8s                     struct {
 		DataPersistence string `yaml:"dataPersistence,omitempty"`
 		ServiceType     string `yaml:"serviceType,omitempty"`
 	} `yaml:"k8s,omitempty"`

--- a/tools/operator/scripts/upgradeNetwork.sh
+++ b/tools/operator/scripts/upgradeNetwork.sh
@@ -1,0 +1,155 @@
+#!/bin/bash -e
+#
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# MSPID=$2
+# NAME=$3
+# ORG_NAME=$4
+# ARTIFACTS_LOCATION=$5
+# NUM_CHANNELS=$6
+# CAPABILITY=$7
+# GROUP=$8
+# PEERORG_MSPID=$9
+# PEERORG_NAME=${10}
+# "Usage: ./upgradeNetwork.sh upgradeDB $MSPID $NAME $ORG_NAME $ARTIFACTS_LOCATION"
+# "Usage: ./upgradeNetwork.sh configUpdate $MSPID $NAME $ORG_NAME $ARTIFACTS_LOCATION $NUM_CHANNELS $CAPABILITY $GROUP $PEERORG_MSPID $PEERORG_NAME"
+
+setGlobals(){
+  export FABRIC_CFG_PATH=$GOPATH/config/
+  export ORDERER_ADDRESS=localhost:30000
+
+  export CORE_PEER_LOCALMSPID=$1
+  export CORE_PEER_TLS_ENABLED=true
+  if [ $4 == "orderer" ]; then
+    export CORE_PEER_MSPCONFIGPATH="$3/crypto-config/ordererOrganizations/$2/users/Admin@$2/msp"
+    export CORE_PEER_TLS_ROOTCERT_FILE="$3/crypto-config/ordererOrganizations/$2/orderers/orderer0-$2.$2/tls/ca.crt"
+  elif [ $4 == "peer" ]; then
+    export CORE_PEER_MSPCONFIGPATH="$3/crypto-config/peerOrganizations/$2/users/Admin@$2/msp"
+  fi
+}
+
+modifyConfig(){
+  GROUP=$1
+  POLICY=$2
+
+  if [ $GROUP == "orderer" ]; then
+    jq -s '.[0] * {"channel_group":{"groups":{"Orderer": {"values": {"Capabilities": '$POLICY'}}}}}' config.json > modified_config.json
+  elif [ $GROUP == "channel" ]; then
+    jq -s '.[0] * {"channel_group":{"values": {"Capabilities": '$POLICY'}}}' config.json > modified_config.json
+  elif [ $GROUP == "application" ]; then
+    jq -s '.[0] * {"channel_group":{"groups":{"Application": {"values": {"Capabilities": '$POLICY'}}}}}' config.json > modified_config.json
+  elif [ $GROUP == "consortium" ]; then
+    jq -s '.[0] * {"channel_group":{"groups":{"Consortiums":{"groups": {"FabricConsortium": {"groups": '$POLICY'}}}}}}' config.json > modified_config.json
+  elif [ $GROUP == "organization" ]; then
+    jq -s '.[0] * {"channel_group":{"groups":{"Application":{"groups": '$POLICY'}}}}' config.json > modified_config.json
+  elif [ $GROUP == "apppolicy" ]; then
+    jq -s '.[0] * {"channel_group":{"groups":{"Application":{"policies": '$POLICY'}}}}' config.json > modified_config.json
+  elif [ $GROUP == "acls" ]; then
+    jq -s '.[0] * {"channel_group":{"groups":{"Application":{"values": {"ACLs": {"mod_policy": "Admins", "value": {"acls": '$POLICY'}}}}}}}' config.json > modified_config.json
+  fi
+}
+
+configtxlatorUpdate(){
+  configtxlator proto_decode --input config_block.pb --type common.Block | jq .data.data[0].payload.data.config > config.json
+
+  modifyConfig $2 $3
+
+  configtxlator proto_encode --input config.json --type common.Config --output config.pb
+  configtxlator proto_encode --input modified_config.json --type common.Config --output modified_config.pb
+  configtxlator compute_update --channel_id $1 --original config.pb --updated modified_config.pb --output modified_update.pb
+  configtxlator proto_decode --input modified_update.pb --type common.ConfigUpdate | jq . > modified_update.json
+  echo '{"payload":{"header":{"channel_header":{"channel_id":"'$1'", "type":2}},"data":{"config_update":'$(cat modified_update.json)'}}}' | jq . > modified_update_in_envelope.json
+  configtxlator proto_encode --input modified_update_in_envelope.json --type common.Envelope --output modified_update_in_envelope.pb
+}
+
+modifyAndSubmit(){
+  MSPID=$1
+  NAME=$2
+  ORG_NAME=$3
+  ARTIFACTS_LOCATION=$4
+  CHANNEL_NAME=$5
+  CAPABILITY=$6
+  GROUP=$7
+  PEERORG_MSPID=$8
+  PEERORG_NAME=$9
+  
+  if [ $GROUP == "orderer" ] || [ $GROUP == "channel" ] || [ $GROUP == "application" ]; then
+    POLICY=('{"mod_policy":"Admins","value":{"capabilities":{"'$CAPABILITY'":{}}},"version":"0"}')
+  elif [ $GROUP == "consortium" ] || [ $GROUP == "organization" ]; then
+    POLICY=('{"'$PEERORG_NAME'":{"policies":{"Endorsement":{"mod_policy":"Admins","policy":{"type":1,"value":{"identities":[{"principal":{"msp_identifier":"'$PEERORG_MSPID'","role":"MEMBER"},"principal_classification":"ROLE"}],"rule":{"n_out_of":{"n":1,"rules":[{"signed_by":0}]}},"version":0}},"version":"0"}}}}')
+  elif [ $GROUP == "apppolicy" ]; then
+    POLICY=('{"Endorsement":{"mod_policy":"Admins","policy":{"type":3,"value":{"rule":"ANY","sub_policy":"Endorsement"}},"version":"0"},"LifecycleEndorsement":{"mod_policy":"Admins","policy":{"type":3,"value":{"rule":"ANY","sub_policy":"Endorsement"}},"version":"0"}}')
+  elif [ $GROUP == "acls" ]; then
+    POLICY=('{"_lifecycle/CommitChaincodeDefinition":{"policy_ref":"/Channel/Application/Writers"},"_lifecycle/QueryChaincodeDefinition":{"policy_ref":"/Channel/Application/Readers"},"_lifecycle/QueryNamespaceDefinitions":{"policy_ref":"/Channel/Application/Readers"}}')
+  fi
+
+  rm -rf config
+  mkdir config
+  cd config/
+
+  echo "Fetching config block for channel $CHANNEL_NAME"
+  setGlobals $MSPID $ORG_NAME $ARTIFACTS_LOCATION orderer
+  peer channel fetch config config_block.pb -o $ORDERER_ADDRESS -c $CHANNEL_NAME --tls --cafile $CORE_PEER_TLS_ROOTCERT_FILE --ordererTLSHostnameOverride $NAME
+
+  configtxlatorUpdate $CHANNEL_NAME $GROUP $POLICY
+
+  if [ $GROUP == "application" ] || [ $GROUP == "organization" ] || [ $GROUP == "apppolicy" ] || [ $GROUP == "acls" ] || [ $GROUP == "consortium" ]; then
+    setGlobals $PEERORG_MSPID $PEERORG_NAME $ARTIFACTS_LOCATION peer
+    peer channel signconfigtx -f modified_update_in_envelope.pb
+    setGlobals $MSPID $ORG_NAME $ARTIFACTS_LOCATION orderer
+  fi
+  echo "Submitting channel config update for $CHANNEL_NAME"
+  peer channel update -f modified_update_in_envelope.pb -c $CHANNEL_NAME -o $ORDERER_ADDRESS --tls --cafile $CORE_PEER_TLS_ROOTCERT_FILE --ordererTLSHostnameOverride $NAME
+  rm *.json *.pb
+}
+
+upgradeDB(){
+  setGlobals $1 $3 $4 peer
+  cd configFiles/backup/$2
+  export CORE_PEER_FILESYSTEMPATH=$PWD
+  peer node upgrade-dbs
+  cd -
+}
+
+configUpdate(){
+  sleep 15
+  if [ $7 == "orderer" ] || [ $7 == "channel" ] || [ $7 == "consortium" ]; then
+    CHANNELS=("orderersystemchannel")
+  elif [ $7 == "application" ] || [ $7 == "organization" ] || [ $7 == "apppolicy" ] || [ $7 == "acls" ]; then
+    CHANNELS=()
+  fi
+
+  for (( i=0; i < $5; ++i ))
+  do
+    CHANNELS+=("testorgschannel$i")
+  done
+
+  for i in ${CHANNELS[*]}
+  do
+    echo "Calling modifyAndSubmit to update "$7" capability/policy for channel $i"
+    modifyAndSubmit $1 $2 $3 $4 $i $6 $7 $8 $9
+  done
+}
+
+if [ $1 == "upgradeDB" ]; then
+  if [ $# != 5 ]; then
+    echo "Invalid number of arguments. Usage:"
+    echo "./upgradeNetwork.sh upgradeDB <peerorg-mspid> <peer-name> <peerorg-name> <artifacts-location>"
+    exit 1
+  else
+    echo "Executing: upgradeDB $2 $3 $4 $5"
+    upgradeDB $2 $3 $4 $5
+  fi
+elif [ $1 == "configUpdate" ]; then
+  if [ $# != 10 ]; then
+    echo "Invalid number of arguments. Usage:"
+    echo "./upgradeNetwork.sh configUpdate <ordererorg-mspid> <orderer-name> <ordererorg-name> <artifacts-location> <numchannels> <capability> <group> <peerorg-mspid> <peerorg-name>"
+    exit 1
+  else
+    echo "Executing: configUpdate $2 $3 $4 $5 $6 $7 $8 $9 ${10}"
+    configUpdate $2 $3 $4 $5 $6 $7 $8 $9 ${10}
+  fi
+fi

--- a/tools/operator/templates/docker/docker-compose.yaml
+++ b/tools/operator/templates/docker/docker-compose.yaml
@@ -139,6 +139,7 @@
 #@       env.append("ORDERER_GENERAL_CLUSTER_CLIENTPRIVATEKEY=/etc/hyperledger/fabric/artifacts/msp/crypto-config/ordererOrganizations/{}/orderers/orderer{}-{}.{}/tls/server.key".format(org.name, j, org.name, org.name))
 #@       env.append("ORDERER_GENERAL_CLUSTER_CLIENTCERTIFICATE=/etc/hyperledger/fabric/artifacts/msp/crypto-config/ordererOrganizations/{}/orderers/orderer{}-{}.{}/tls/server.crt".format(org.name, j, org.name, org.name))
 #@       volumes = ["{}:/etc/hyperledger/fabric/artifacts/msp/".format(artifactsLocation)]
+#@       volumes.append("./backup/orderer{}-{}:/var/hyperledger/production/orderer".format(j, org.name))
 #@       container_name = "orderer{}-{}".format(j,org.name)
 #@       image = "hyperledger/fabric-orderer:{}".format(config.fabricVersion)
 #@       if config.fabricVersion.endswith("-stable"):
@@ -194,6 +195,7 @@
 #@       container_name = "peer{}-{}".format(j, org.name)
 #@       volumes = ["{}:/etc/hyperledger/fabric/artifacts/msp/".format(artifactsLocation)]
 #@       volumes.append("/var/run/:/host/var/run/")
+#@       volumes.append("./backup/peer{}-{}:/var/hyperledger/production".format(j, org.name))
 #@       image = "hyperledger/fabric-peer:{}".format(config.fabricVersion)
 #@       if config.fabricVersion.endswith("-stable"):
 #@         env.append("CORE_CHAINCODE_BUILDER=nexus3.hyperledger.org:10001/hyperledger/fabric-ccenv:amd64-{}".format(config.fabricVersion))


### PR DESCRIPTION
Adding upgrade network option to operator. For example:
`go run main.go -i <network-spec-file> -a upgradeNetwork`

Above command will take down existing fabric network, upgrade
all peer db's, relaunch fabric network using 2.0 images, update
capabilities for orderer system channel and all application
channels, update policies for consortium on orderer system
channel, update policies for each organization, app policies,
acls on all application channels.

Signed-off-by: Surya Lanka <suryalnvs@gmail.com>