### PR TITLE
Use Apache 2.0 license

### DIFF
--- a/tools/NL/package.json
+++ b/tools/NL/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Dongming Hwang",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "dependencies": {
     "js-yaml": "^3.13.1",
     "winston": "^3.2.1",

--- a/tools/PTE/CITest/scripts/package.json
+++ b/tools/PTE/CITest/scripts/package.json
@@ -6,7 +6,7 @@
     "test": "mkdir tap_output && TAP_FILE=./tap_output/results.tap node_modules/.bin/mocha -b --exit $NODE_DEBUG_OPTION test/test.js --reporter tap-file --timeout 900000"
   },
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "dependencies": {
     "fs-extra": "^7.0.1",
     "shelljs": "^0.8.3",


### PR DESCRIPTION
A couple of the Node apps were using the default ISC license generated by `npm init`.