### PR TITLE
[FAB-17103] Adding backup for orderers and peers

### DIFF
--- a/tools/operator/launcher/dockercompose/network.go
+++ b/tools/operator/launcher/dockercompose/network.go
@@ -2,6 +2,7 @@ package dockercompose
 
 import (
 	"strings"
+	"fmt"
 
 	"github.com/hyperledger/fabric-test/tools/operator/launcher/nl"
 	"github.com/hyperledger/fabric-test/tools/operator/logger"
@@ -58,10 +59,19 @@ func (d DockerCompose) DownLocalNetwork(config networkspec.Config) error {
 	if err != nil {
 		return err
 	}
+
+	configDirPath := paths.ConfigFilesDir()
+	cleanArgs := []string{"run", "--rm", "-v", fmt.Sprintf("%s/backup:/opt/backup", configDirPath), "busybox", "sh", "-c", "(rm -rf /opt/backup/*)"}
+	_, err = networkclient.ExecuteCommand("docker", cleanArgs, true)
+	if err != nil {
+		return err
+	}
+
 	err = network.NetworkCleanUp(config)
 	if err != nil {
 		return err
 	}
+
 	err = d.removeChainCodeContainersAndImages()
 	if err != nil {
 		return err

--- a/tools/operator/templates/docker/docker-compose.yaml
+++ b/tools/operator/templates/docker/docker-compose.yaml
@@ -139,6 +139,7 @@
 #@       env.append("ORDERER_GENERAL_CLUSTER_CLIENTPRIVATEKEY=/etc/hyperledger/fabric/artifacts/msp/crypto-config/ordererOrganizations/{}/orderers/orderer{}-{}.{}/tls/server.key".format(org.name, j, org.name, org.name))
 #@       env.append("ORDERER_GENERAL_CLUSTER_CLIENTCERTIFICATE=/etc/hyperledger/fabric/artifacts/msp/crypto-config/ordererOrganizations/{}/orderers/orderer{}-{}.{}/tls/server.crt".format(org.name, j, org.name, org.name))
 #@       volumes = ["{}:/etc/hyperledger/fabric/artifacts/msp/".format(artifactsLocation)]
+#@       volumes.append("./backup/orderer{}-{}:/var/hyperledger/production/orderer".format(j, org.name))
 #@       container_name = "orderer{}-{}".format(j,org.name)
 #@       image = "hyperledger/fabric-orderer:{}".format(config.fabricVersion)
 #@       if config.fabricVersion.endswith("-stable"):
@@ -194,6 +195,7 @@
 #@       container_name = "peer{}-{}".format(j, org.name)
 #@       volumes = ["{}:/etc/hyperledger/fabric/artifacts/msp/".format(artifactsLocation)]
 #@       volumes.append("/var/run/:/host/var/run/")
+#@       volumes.append("./backup/peer{}-{}:/var/hyperledger/production".format(j, org.name))
 #@       image = "hyperledger/fabric-peer:{}".format(config.fabricVersion)
 #@       if config.fabricVersion.endswith("-stable"):
 #@         env.append("CORE_CHAINCODE_BUILDER=hyperledger-fabric.jfrog.io/fabric-ccenv:amd64-{}".format(config.fabricVersion))


### PR DESCRIPTION
Adding volume mounts for orderers and peers in docker-compose.yaml and cleaning up backups during network down.

Signed-off-by: Surya Lanka <suryalnvs@gmail.com>