### PR TITLE
[FAB-17404] Add Windows and Darwin Binaries to Artifactory

### DIFF
--- a/ci/scripts/trigger_publish_artifacts.sh
+++ b/ci/scripts/trigger_publish_artifacts.sh
@@ -14,16 +14,25 @@ for image in baseos peer orderer ccenv tools ca javaenv nodeenv; do
     docker push "hyperledger-fabric.jfrog.io/fabric-${image}:amd64-latest"
 done
 
-cd "${GOPATH}/src/github.com/hyperledger/fabric/release/linux-amd64/"
-mkdir -p "config"
-cp ../../sampleconfig/*yaml "config"
-tar -czvf "hyperledger-fabric-linux-amd64-${RELEASE}.tar.gz" bin config
-curl -u"${ARTIFACTORY_USERNAME}":"${ARTIFACTORY_PASSWORD}" \
-     -T "./release/linux-amd64/hyperledger-fabric-linux-amd64-${RELEASE}.tar.gz" \
-     "https://hyperledger.jfrog.io/hyperledger/fabric-binaries/hyperledger-fabric-linux-amd64-${RELEASE}.tar.gz"
 
-cd "${GOPATH}/src/github.com/hyperledger/fabric-ca/release/linux-amd64"
-tar -czvf "hyperledger-fabric-ca-linux-amd64-${RELEASE}.tar.gz" bin
-curl -u"${ARTIFACTORY_USERNAME}":"${ARTIFACTORY_PASSWORD}" \
-     -T "./release/linux-amd64/hyperledger-fabric-ca-linux-amd64-${RELEASE}.tar.gz" \
-     "https://hyperledger.jfrog.io/hyperledger/fabric-binaries/hyperledger-fabric-ca-linux-amd64-${RELEASE}.tar.gz"
+for target in linux-amd64 darwin-amd64 windows-amd64; do
+    cd "${GOPATH}/src/github.com/hyperledger/fabric"
+    make "release/${target}"
+
+    cd "release/${target}/"
+    mkdir -p "config"
+    cp ../../sampleconfig/*yaml "config"
+    tar -czvf "hyperledger-fabric-${target}-${RELEASE}.tar.gz" bin config
+    curl -u"${ARTIFACTORY_USERNAME}":"${ARTIFACTORY_PASSWORD}" \
+         -T "hyperledger-fabric-${target}-${RELEASE}.tar.gz" \
+         "https://hyperledger.jfrog.io/hyperledger/fabric-binaries/hyperledger-fabric-${target}-${RELEASE}.tar.gz"
+
+    cd "${GOPATH}/src/github.com/hyperledger/fabric-ca"
+    make "release/${target}"
+
+    cd "release/${target}"
+    tar -czvf "hyperledger-fabric-ca-${target}-${RELEASE}.tar.gz" bin
+    curl -u"${ARTIFACTORY_USERNAME}":"${ARTIFACTORY_PASSWORD}" \
+         -T "hyperledger-fabric-ca-${target}-${RELEASE}.tar.gz" \
+         "https://hyperledger.jfrog.io/hyperledger/fabric-binaries/hyperledger-fabric-ca-${target}-${RELEASE}.tar.gz"
+done


### PR DESCRIPTION
This change adds the MacOS and Windows binaries to Artificatory alongside Linux

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>