### PR TITLE
Fix CODEOWNERS path from chaincode-integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 
 # Fabric Test Maintainers
 *	@btl5037 @denyeart @dongmingh @mastersingh24 @scottz64 @suryalnvs
-/tools/chaincode-integration @awjh-ibm @mbwhite
+/tools/chaincode-integration/ @awjh-ibm @mbwhite


### PR DESCRIPTION
PR #56 introduced a CODEOWNERS entry for tools/chaincode-integration. This entry was missing the trailing slash to mark all sub folders of that directory as being owned by awjh-ibm and mbwhite