### PR TITLE
[FAB-17217] update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Fabric Test Maintainers
-*	@bmos299 @christo4ferris @denyeart @dongmingh @lhaskins @mastersingh24 @scottz64 @adnan-c
+*	@btl5037 @denyeart @dongmingh @mastersingh24 @scottz64 @suryalnvs


### PR DESCRIPTION
This CR is to update code owners file in
fabric-test release 1.4
1. remove Barry Mosakowski Latitia Haskins
   Adnan Choudhury and Christopher Ferris
2. add Naga Venkata Sai Surya Teja Lanka
   and Brett Logan

Signed-off-by: Dongming Hwang <dongming@ibm.com>