### PR TITLE
Enable Mergify for chaincode-integration tool

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,9 @@
+pull_request_rules:
+  - name: Auto-Merge on Approving Label and Changes Limited to tools/chaincode-integration/ Folder
+    conditions:
+      - files~=^tools/chaincode-integration/
+      - -files~=^(?!^tools/chaincode-integration).*
+      - label=merge-ready
+    actions:
+      merge:
+        method: rebase


### PR DESCRIPTION
Adds ability for chaincode-integration maintainers to merge code once all usual conditions are met (+1 CODEOWNERS and CI success) by adding a merge-ready label to the PR. I've tested this in my own repo to confirm when a PR contains changes both in the /tools/chaincode-integration directory and outside it, the PR is not merged.

This repo contains code merged using the rule, and an open PR that validates the above mentioned scenario does not occur: https://github.com/btl5037/fabric-utilities/pulls

Negative lookahead RegEx verification: https://regexr.com/4sumv

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>