### PR TITLE
[FAB-17462] check if vendor folder exists before go mod vendor

### DIFF
--- a/tools/chaincode-integration/src/step-definitions/chaincode/chaincode.ts
+++ b/tools/chaincode-integration/src/step-definitions/chaincode/chaincode.ts
@@ -35,7 +35,7 @@ export class Chaincode {
         if (this.workspace.language !== 'golang') {
             prefix = '/opt/gopath/src/';
         } else {
-            await Docker.exec(channel.organisations[0].cli, `bash -c 'cd /opt/gopath/src/github.com/hyperledger/fabric-chaincode-integration/${chaincodeName} && go mod vendor'`);
+            await Docker.exec(channel.organisations[0].cli, `bash -c 'cd /opt/gopath/src/github.com/hyperledger/fabric-chaincode-integration/${chaincodeName} && if [ ! -d "vendor" ]; then go mod vendor; fi'`);
         }
 
         for (const org of channel.organisations) {


### PR DESCRIPTION
[FAB-17462](https://jira.hyperledger.org/browse/FAB-17462)

Add check for if vendor folder exists in Go chaincode before running `go mod vendor` to allow use of existing vendored modules