### PR TITLE
[FAB-17473] Fixing running operator parallel when multiple orgs are given in install, instantiation and invoke

### DIFF
--- a/tools/operator/connectionprofile/updateconncectionprofile.go
+++ b/tools/operator/connectionprofile/updateconncectionprofile.go
@@ -69,7 +69,7 @@ func (c ConnProfile) updateConnectionProfilePerOrg(organizations []inputStructs.
 		return errors.New("Incorrect number of arguments passed")
 	}
 	action, orgName, channelName := inputArgs[0], inputArgs[1], inputArgs[2]
-	connProfilePath := paths.GetConnProfilePathForOrg(orgName, organizations)
+	connProfilePath := paths.GetConnProfilePath([]string{orgName}, organizations)
 	connectionProfilesList = append(connectionProfilesList, connProfilePath)
 	if !strings.HasSuffix(connProfilePath, ".yaml") && !strings.HasSuffix(connProfilePath, ".yml") {
 		connectionProfilesList = []string{}

--- a/tools/operator/paths/paths.go
+++ b/tools/operator/paths/paths.go
@@ -158,12 +158,17 @@ func PTEPath() string {
 	return path
 }
 
-//GetConnProfilePathForOrg --
-func GetConnProfilePathForOrg(orgName string, organizations []inputStructs.Organization) string {
+//GetConnProfilePath --
+func GetConnProfilePath(orgNames []string, organizations []inputStructs.Organization) string {
 	var connProfilePath string
-	for i := 0; i < len(organizations); i++ {
-		if organizations[i].Name == orgName {
-			connProfilePath = organizations[i].ConnProfilePath
+	if len(orgNames) > 1 {
+		connProfilePath,_ = filepath.Split(organizations[0].ConnProfilePath)
+	} else {
+		for i := 0; i < len(organizations); i++ {
+			if organizations[i].Name == orgNames[0] {
+				connProfilePath = organizations[i].ConnProfilePath
+				break;
+			}
 		}
 	}
 	return connProfilePath

--- a/tools/operator/testclient/operations/channelConfig.go
+++ b/tools/operator/testclient/operations/channelConfig.go
@@ -92,7 +92,7 @@ func (c ChannelUIObject) createChannelConfigObjects(orgNames []string, channelNa
 			channelTxPath = anchorPeerTxPath
 		}
 		channelOpt = ChannelOptions{Name: channelName, Action: action, OrgName: []string{orgName}, ChannelTX: channelTxPath}
-		c = ChannelUIObject{TransType: "Channel", TLS: tls, ConnProfilePath: paths.GetConnProfilePathForOrg(orgName, organizations), ChannelOpt: channelOpt, OrdererSystemChannel: ordererChannel}
+		c = ChannelUIObject{TransType: "Channel", TLS: tls, ConnProfilePath: paths.GetConnProfilePath([]string{orgName}, organizations), ChannelOpt: channelOpt, OrdererSystemChannel: ordererChannel}
 		channelObjects = append(channelObjects, c)
 	}
 	return channelObjects

--- a/tools/operator/testclient/operations/installchaincode.go
+++ b/tools/operator/testclient/operations/installchaincode.go
@@ -53,16 +53,13 @@ func (i InstallCCUIObject) createInstallCCObjects(ccObject inputStructs.InstallC
 	var deployOpt InstallCCDeployOpt
 	i = InstallCCUIObject{TransType: "install", TLS: tls, ChainCodeVer: ccObject.ChainCodeVersion, ChainCodeID: ccObject.ChainCodeName}
 	orgNames := strings.Split(ccObject.Organizations, ",")
-	for _, orgName := range orgNames {
-		orgName = strings.TrimSpace(orgName)
-		channelOpt = ChannelOptions{OrgName: []string{orgName}}
-		deployOpt = InstallCCDeployOpt{ChainCodePath: ccObject.ChainCodePath, Language: ccObject.Language}
-		deployOpt.MetadataPath = ccObject.MetadataPath
-		i.DeployOpt = deployOpt
-		i.ChannelOpt = channelOpt
-		i.ConnProfilePath = paths.GetConnProfilePathForOrg(orgName, organizations)
-		installCCObjects = append(installCCObjects, i)
-	}
+	channelOpt = ChannelOptions{OrgName: orgNames}
+	deployOpt = InstallCCDeployOpt{ChainCodePath: ccObject.ChainCodePath, Language: ccObject.Language}
+	deployOpt.MetadataPath = ccObject.MetadataPath
+	i.DeployOpt = deployOpt
+	i.ChannelOpt = channelOpt
+	i.ConnProfilePath = paths.GetConnProfilePath(orgNames, organizations)
+	installCCObjects = append(installCCObjects, i)
 	return installCCObjects
 }
 

--- a/tools/operator/testclient/operations/instantiatechaincode.go
+++ b/tools/operator/testclient/operations/instantiatechaincode.go
@@ -121,28 +121,25 @@ func (i InstantiateCCUIObject) generateInstantiateCCObjects(ccObject inputStruct
 func (i InstantiateCCUIObject) createInstantiateCCObjects(orgNames []string, channelName, tls, action string, organizations []inputStructs.Organization, ccObject inputStructs.InstantiateCC) ([]InstantiateCCUIObject, error) {
 
 	var instantiateCCObjects []InstantiateCCUIObject
-	for _, orgName := range orgNames {
-		orgName = strings.TrimSpace(orgName)
-		i = InstantiateCCUIObject{TransType: action, TLS: tls, ConnProfilePath: paths.GetConnProfilePathForOrg(orgName, organizations), ChainCodeID: ccObject.ChainCodeName, ChainCodeVer: ccObject.ChainCodeVersion}
-		i.ChannelOpt = ChannelOptions{Name: channelName, OrgName: []string{orgName}}
-		i.DeployOpt = InstantiateDeployOptions{Function: ccObject.CCFcn, Arguments: strings.Split(ccObject.CCFcnArgs, ",")}
-		i.TimeOutOpt = TimeOutOptions{PreConfig: ccObject.TimeOutOpt.PreConfig, Request: ccObject.TimeOutOpt.Request}
-		if ccObject.TimeOutOpt.PreConfig == "" {
-			i.TimeOutOpt = TimeOutOptions{PreConfig: "600000", Request: "600000"}
-		}
-		if ccObject.EndorsementPolicy != "" {
-			endorsementPolicy, err := i.getEndorsementPolicy(organizations, ccObject.EndorsementPolicy)
-			if err != nil {
-				logger.ERROR("Failed to get the endorsement policy")
-				return instantiateCCObjects, err
-			}
-			i.DeployOpt.Endorsement = endorsementPolicy
-		}
-		if ccObject.CollectionPath != "" {
-			i.DeployOpt.CollectionsConfigPath = ccObject.CollectionPath
-		}
-		instantiateCCObjects = append(instantiateCCObjects, i)
+	i = InstantiateCCUIObject{TransType: action, TLS: tls, ConnProfilePath: paths.GetConnProfilePath(orgNames, organizations), ChainCodeID: ccObject.ChainCodeName, ChainCodeVer: ccObject.ChainCodeVersion}
+	i.ChannelOpt = ChannelOptions{Name: channelName, OrgName: orgNames}
+	i.DeployOpt = InstantiateDeployOptions{Function: ccObject.CCFcn, Arguments: strings.Split(ccObject.CCFcnArgs, ",")}
+	i.TimeOutOpt = TimeOutOptions{PreConfig: ccObject.TimeOutOpt.PreConfig, Request: ccObject.TimeOutOpt.Request}
+	if ccObject.TimeOutOpt.PreConfig == "" {
+		i.TimeOutOpt = TimeOutOptions{PreConfig: "600000", Request: "600000"}
 	}
+	if ccObject.EndorsementPolicy != "" {
+		endorsementPolicy, err := i.getEndorsementPolicy(organizations, ccObject.EndorsementPolicy)
+		if err != nil {
+			logger.ERROR("Failed to get the endorsement policy")
+			return instantiateCCObjects, err
+		}
+		i.DeployOpt.Endorsement = endorsementPolicy
+	}
+	if ccObject.CollectionPath != "" {
+		i.DeployOpt.CollectionsConfigPath = ccObject.CollectionPath
+	}
+	instantiateCCObjects = append(instantiateCCObjects, i)
 	return instantiateCCObjects, nil
 }
 
@@ -177,7 +174,7 @@ func (i InstantiateCCUIObject) getEndorsementPolicy(organizations []inputStructs
 
 	for _, orgName := range orgNames {
 		orgName = strings.TrimSpace(orgName)
-		connProfilePath := paths.GetConnProfilePathForOrg(orgName, organizations)
+		connProfilePath := paths.GetConnProfilePath([]string{orgName}, organizations)
 		mspID, err := i.getMSPIDForOrg(connProfilePath, orgName)
 		if err != nil {
 			return endorsementPolicy, err

--- a/tools/operator/testclient/operations/invokequery.go
+++ b/tools/operator/testclient/operations/invokequery.go
@@ -113,16 +113,13 @@ func (i InvokeQueryUIObject) generateInvokeQueryObjects(invkQueryObject inputStr
 
 	var invokeQueryObjects []InvokeQueryUIObject
 	orgNames := strings.Split(invkQueryObject.Organizations, ",")
-	for _, orgName := range orgNames {
-		orgName = strings.TrimSpace(orgName)
-		invkQueryObjects := i.createInvokeQueryObjectForOrg(orgName, action, tls, organizations, invkQueryObject)
-		invokeQueryObjects = append(invokeQueryObjects, invkQueryObjects...)
-	}
+	invkQueryObjects := i.createInvokeQueryObjectForOrg(orgNames, action, tls, organizations, invkQueryObject)
+	invokeQueryObjects = append(invokeQueryObjects, invkQueryObjects...)
 	return invokeQueryObjects
 }
 
 //createInvokeQueryObjectForOrg -- To craete invoke/query objects for an organization
-func (i InvokeQueryUIObject) createInvokeQueryObjectForOrg(orgName, action, tls string, organizations []inputStructs.Organization, invkQueryObject inputStructs.InvokeQuery) []InvokeQueryUIObject {
+func (i InvokeQueryUIObject) createInvokeQueryObjectForOrg(orgNames []string, action, tls string, organizations []inputStructs.Organization, invkQueryObject inputStructs.InvokeQuery) []InvokeQueryUIObject {
 
 	var invokeQueryObjects []InvokeQueryUIObject
 	invokeParams := make(map[string]Parameters)
@@ -145,8 +142,8 @@ func (i InvokeQueryUIObject) createInvokeQueryObjectForOrg(orgName, action, tls 
 		i.InvokeType = action
 		i.CCOpt = CCOptions{KeyStart: strconv.Itoa(invkQueryObject.CCOptions.KeyStart)}
 	}
-	i.ChannelOpt = ChannelOptions{Name: invkQueryObject.ChannelName, OrgName: []string{orgName}}
-	i.ConnProfilePath = paths.GetConnProfilePathForOrg(orgName, organizations)
+	i.ChannelOpt = ChannelOptions{Name: invkQueryObject.ChannelName, OrgName: orgNames}
+	i.ConnProfilePath = paths.GetConnProfilePath(orgNames, organizations)
 	invokeParams["move"] = Parameters{Fcn: invkQueryObject.Fcn, Args: strings.Split(invkQueryObject.Args, ",")}
 	invokeParams["query"] = Parameters{Fcn: invkQueryObject.Fcn, Args: strings.Split(invkQueryObject.Args, ",")}
 	i.Parameters = invokeParams


### PR DESCRIPTION
Operator to run install, instantiate and invokes in parallel when multiple orgs are specified.

When multiple organizations are passed as shown: `organizations: org1,org2`, operator should pass connection profile directory to PTE for reading all connection profiles and sending invokes using a single run.