### PR TITLE
[FAB-17494] Normalize Logging

### DIFF
--- a/regression/barebones/runBarebonesTestSuite.sh
+++ b/regression/barebones/runBarebonesTestSuite.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -9,18 +8,18 @@
 #     local network: if the environment varibale KUBECONFIG is not set.
 # The test output is in $FabricTestDir/regression/barebones/barebones-pteReport.log
 
-CurrentDirectory=$(cd `dirname $0` && pwd)
-FabricTestDir="$(echo $CurrentDirectory | awk -F'/fabric-test/' '{print $1}')/fabric-test"
-BAREBONESDIR="$FabricTestDir/regression/barebones"
+CurrentDirectory=$(cd $(dirname $0) && pwd)
+FabricTestDir="$(echo ${CurrentDirectory} | awk -F'/fabric-test/' '{print $1}')/fabric-test"
+BAREBONESDIR="${FabricTestDir}/regression/barebones"
 
 echo "======== Barebones Test Suite using ginkgo and operator tools ========"
-cd $BAREBONESDIR && ginkgo -v
+cd ${BAREBONESDIR} && ginkgo
 StatusOperator=$?
 
-if [ $StatusOperator == 0 ] && [ $StatusPteNL == 0 ]; then
-    echo "------> Barebones tests completed"
-    echo "------> Test output: $FabricTestDir/regression/barebones/barebones-pteReport.log"
+if [[ ${StatusOperator} == 0 ]] && [[ ${StatusPteNL} == 0 ]]; then
+	echo "------> Barebones tests completed"
+	echo "------> Test output: ${FabricTestDir}/regression/barebones/barebones-pteReport.log"
 else
-    echo "------> Barebones tests failed with above errors"
-    exit 1
+	echo "------> Barebones tests failed with above errors"
+	exit 1
 fi

--- a/regression/daily/runPteTestSuite.sh
+++ b/regression/daily/runPteTestSuite.sh
@@ -4,22 +4,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-CurrentDirectory=$(cd `dirname $0` && pwd)
-FabricTestDir="$(echo $CurrentDirectory | awk -F'/fabric-test/' '{print $1}')/fabric-test"
-DAILYDIR="$FabricTestDir/regression/daily"
-BAREBONESDIR="$FabricTestDir/regression/barebones"
+CurrentDirectory=$(cd $(dirname $0) && pwd)
+FabricTestDir="$(echo ${CurrentDirectory} | awk -F'/fabric-test/' '{print $1}')/fabric-test"
+DAILYDIR="${FabricTestDir}/regression/daily"
+BAREBONESDIR="${FabricTestDir}/regression/barebones"
 
 echo "========== System Test Barebones tests using PTE and operator tools..."
-cd $BAREBONESDIR && ginkgo -v
+cd ${BAREBONESDIR} && ginkgo
 StatusBarebones=$?
 
-if [ $StatusBarebones == 0 ]; then
-    echo "------> Barebones tests completed"
+if [[ ${StatusBarebones} == 0 ]]; then
+	echo "------> Barebones tests completed"
 else
-    echo "------> Barebones tests failed with above errors"
-    exit 1
+	echo "------> Barebones tests failed with above errors"
+	exit 1
 fi
-# save barebones test result
-tCurr=`date +%Y%m%d`
-cp $FabricTestDir/regression/barebones/barebones-pteReport.log $DAILYDIR"/barebones-pteReport-"$tCurr".log"
 
+# save barebones test result
+tCurr=$(date +%Y%m%d)
+cp ${FabricTestDir}/regression/barebones/barebones-pteReport.log ${DAILYDIR}"/barebones-pteReport-"${tCurr}".log"

--- a/regression/smoke/runSmokeTestSuite.sh
+++ b/regression/smoke/runSmokeTestSuite.sh
@@ -1,21 +1,19 @@
 #!/bin/bash
-#
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
-CurrentDirectory=$(cd `dirname $0` && pwd)
-FabricTestDir="$(echo $CurrentDirectory | awk -F'/fabric-test/' '{print $1}')/fabric-test"
-SMOKEDIR="$FabricTestDir/regression/smoke"
-cd $SMOKEDIR
+CurrentDirectory=$(cd $(dirname $0) && pwd)
+FabricTestDir="$(echo ${CurrentDirectory} | awk -F'/fabric-test/' '{print $1}')/fabric-test"
+SMOKEDIR="${FabricTestDir}/regression/smoke"
 
 echo "======== Smoke Test Suite using ginkgo and operator tools ========"
-cd $SMOKEDIR && ginkgo -v
+cd ${SMOKEDIR} && ginkgo
 StatusOperator=$?
 
-if [ $StatusOperator == 0 ]; then
-    echo "------> Smoke tests completed"
+if [[ ${StatusOperator} == 0 ]]; then
+	echo "------> Smoke tests completed"
 else
-    echo "------> Smoke tests failed with above errors"
-    exit 1
+	echo "------> Smoke tests failed with above errors"
+	exit 1
 fi

--- a/tools/operator/logger/logger.go
+++ b/tools/operator/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -10,24 +11,18 @@ import (
 
 //INFO -- To print the info logs
 func INFO(message ...string) {
-	info := log.New(os.Stdout,
+	writers := io.MultiWriter(os.Stdout, ginkgo.GinkgoWriter)
+	info := log.New(writers,
 		"INFO: ",
 		log.Ldate|log.Ltime)
-	runTests, envVariableExists := os.LookupEnv("GinkoTests")
-	if envVariableExists && runTests == "true" {
-		info.SetOutput(ginkgo.GinkgoWriter)
-	}
 	info.Println(strings.Join(message, ""))
 }
 
 //ERROR -- To print the error logs
 func ERROR(message ...string) {
-	error := log.New(os.Stdout,
+	writers := io.MultiWriter(os.Stdout, ginkgo.GinkgoWriter)
+	error := log.New(writers,
 		"ERROR: ",
 		log.Ldate|log.Ltime)
-	runTests, envVariableExists := os.LookupEnv("GinkoTests")
-	if envVariableExists && runTests == "true" {
-		error.SetOutput(ginkgo.GinkgoWriter)
-	}
 	error.Println(strings.Join(message, ""))
 }


### PR DESCRIPTION
Make use of the fact that GinkgoWriter only sends its output to stdout if the `-v` flag is set or a test suite fails. As such there is no need to use a separate variable to send test output to stdout.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>