### PR TITLE
[FAB-15962] PTE process exits when it receives SERVICE UNAVAILABLE

### DIFF
--- a/tools/PTE/pte-execRequest.js
+++ b/tools/PTE/pte-execRequest.js
@@ -464,6 +464,13 @@ function listenToEventHub() {
 
 var reConnectEvtHub = 0;
 function peerFailover(channel, client) {
+
+    // return if no peer failover or using discovery to send transactions
+    // SDK handles failover when using discovery
+    if ((!peerFO) || (targetPeers === 'DISCOVERY')) {
+        return;
+    }
+
     var currId = currPeerId;
     var eh;
     channel.removePeer(peerList[currPeerId]);
@@ -1095,6 +1102,11 @@ function initDiscovery() {
 
 // reconnect orderer
 function ordererReconnect(channel, client, org) {
+    // SDK handles failover when using discovery
+    if (targetPeers === 'DISCOVERY') {
+        return;
+    }
+
     channel.removeOrderer(ordererList[currOrdererId]);
     channelAddOrderer(channel, client, org);
     logger.info('[Nid:chan:org:id=%d:%s:%s:%d ordererReconnect] Orderer reconnect (%s)', Nid, channel.getName(), org, pid, ordererList[currOrdererId]._url);
@@ -1102,6 +1114,12 @@ function ordererReconnect(channel, client, org) {
 
 // orderer failover
 function ordererFailover(channel, client) {
+    // return if no orderer failover or using discovery to send transactions
+    // SDK handles failover when using discovery
+    if ((!ordererFO) || (targetPeers === 'DISCOVERY')) {
+        return;
+    }
+
     var currId = currOrdererId;
     channel.removeOrderer(ordererList[currOrdererId]);
     currOrdererId = currOrdererId + 1;
@@ -1785,6 +1803,11 @@ function eventRegister(tx) {
 //    failover if failover is set
 //    reconnect if reconn=1
 function ordererHdlr() {
+
+    // SDK handles failover when using discovery
+    if (targetPeers === 'DISCOVERY') {
+        return;
+    }
 
     if (ordererFO) {
         ordererFailover(channel, client);


### PR DESCRIPTION
This PR is to fix the issue that
PTE process exits when it receives SERVICE UNAVAILABLE during
the traffic run with service discovery and restarting leader

The solution is that the client (PTE) does not to failover when
an orderer or a peer fails in the case of using discovery
since SDK determines the targeted peers and orderers to send
transactions.

Signed-off-by: Dongming Hwang <dongming@ibm.com>