### PR TITLE
[FAB-17502] Update operator to support 2.0 lifecycle and endorsement policies

### DIFF
--- a/tools/operator/networkclient/upgradeNetwork.go
+++ b/tools/operator/networkclient/upgradeNetwork.go
@@ -30,7 +30,7 @@ func UpgradeDB(config networkspec.Config, kubeConfigPath string) error {
 //UpdateCapability -  to update capability
 func UpdateCapability(config networkspec.Config, kubeConfigPath string) error {
 	capabilityGroup := "channel"
-	capabilityKey := getKeyFromCapability(config.ChannelCapabilities)
+	capabilityKey := config.ChannelCapabilities
 	args := []string{"configUpdate",
 		config.OrdererOrganizations[0].MSPID,
 		fmt.Sprintf("orderer0-%s", config.OrdererOrganizations[0].Name),
@@ -47,7 +47,7 @@ func UpdateCapability(config networkspec.Config, kubeConfigPath string) error {
 	}
 
 	capabilityGroup = "orderer"
-	capabilityKey = getKeyFromCapability(config.OrdererCapabilities)
+	capabilityKey = config.OrdererCapabilities
 	args = []string{"configUpdate",
 		config.OrdererOrganizations[0].MSPID,
 		fmt.Sprintf("orderer0-%s", config.OrdererOrganizations[0].Name),
@@ -63,7 +63,7 @@ func UpdateCapability(config networkspec.Config, kubeConfigPath string) error {
 	}
 
 	capabilityGroup = "application"
-	capabilityKey = getKeyFromCapability(config.ApplicationCapabilities)
+	capabilityKey = config.ApplicationCapabilities
 	args = []string{"configUpdate",
 		config.OrdererOrganizations[0].MSPID,
 		fmt.Sprintf("orderer0-%s", config.OrdererOrganizations[0].Name),
@@ -141,12 +141,4 @@ func UpdatePolicy(config networkspec.Config, kubeConfigPath string) error {
 
 	logger.INFO("Successfully updated policies")
 	return nil
-}
-
-func getKeyFromCapability(config map[string]string) string {
-	var key string
-	for key = range config {
-		return key
-	}
-	return key
 }

--- a/tools/operator/networkspec/structs.go
+++ b/tools/operator/networkspec/structs.go
@@ -14,9 +14,9 @@ type Config struct {
 	NumChannels             int               `yaml:"numChannels,omitempty"`
 	TLS                     string            `yaml:"tls,omitempty"`
 	EnableNodeOUs           bool              `yaml:"enableNodeOUs,omitempty"`
-	OrdererCapabilities     map[string]string `yaml:"ordererCapabilities,omitempty"`
-	ChannelCapabilities     map[string]string `yaml:"channelCapabilities,omitempty"`
-	ApplicationCapabilities map[string]string `yaml:"applicationCapabilities,omitempty"`
+	OrdererCapabilities     string `yaml:"ordererCapabilities,omitempty"`
+	ChannelCapabilities     string `yaml:"channelCapabilities,omitempty"`
+	ApplicationCapabilities string `yaml:"applicationCapabilities,omitempty"`
 	K8s                     struct {
 		DataPersistence string `yaml:"dataPersistence,omitempty"`
 		ServiceType     string `yaml:"serviceType,omitempty"`

--- a/tools/operator/templates/configtx.yaml
+++ b/tools/operator/templates/configtx.yaml
@@ -3,7 +3,7 @@
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
-#@ def orgPolicies(mspId, type, nodeOUs):
+#@ def orgPolicies(mspId, type, nodeOUs, capability):
 #@   output = {}
 #@   if nodeOUs:
 #@     readwriteset = {"Type": "Signature", "Rule": "OR('{}.admin', '{}.{}', '{}.client')".format(mspId, mspId, type, mspId)}
@@ -13,8 +13,17 @@
 #@     admins = {"Type": "Signature", "Rule": "OR('{}.member')".format(mspId)}
 #@   end
 #@   output = {"Readers": readwriteset, "Writers": readwriteset, "Admins": admins}
+#@   if type == "peer" and capability == "V2_0":
+#@     if nodeOUs:
+#@       endorsement = {"Type": "Signature", "Rule": "OR('{}.peer')".format(mspId)}
+#@     else:
+#@       endorsement = {"Type": "Signature", "Rule": "OR('{}.member')".format(mspId)}
+#@     end
+#@     output = {"Readers": readwriteset, "Writers": readwriteset, "Admins": admins, "Endorsement": endorsement} 
+#@   end
 #@   return output
 #@ end
+
 #@ def orgOrderers(ordererOrg, port, config):
 #@  orderers = []
 #@  for i in range(0, ordererOrg.numOderers):
@@ -27,11 +36,13 @@
 #@  end
 #@  return orderers
 #@ end
+
 #@ def anchorPeers(orgName, port):
 #@  anchorpeers = []
 #@  anchorpeers.append({"Host": "peer0-{}".format(orgName), "Port": port})
 #@  return anchorpeers
 #@ end
+
 #@ def organizations(config, type):
 #@   output = []
 #@   artifactsLocation = config.artifactsLocation
@@ -42,32 +53,40 @@
 #@     port1 = 30000
 #@     num_organizations = len(config.ordererOrganizations)
 #@     for i in range(0, num_organizations):
-#@       output.append({"Name": config.ordererOrganizations[i].name, "OrdererEndpoints": orgOrderers(config.ordererOrganizations[i], port1, config), "ID": config.ordererOrganizations[i].mspId, "MSPDir": artifactsLocation+"crypto-config/ordererOrganizations/"+config.ordererOrganizations[i].name+"/msp", "Policies": orgPolicies(config.ordererOrganizations[i].mspId, "orderer", config.enableNodeOUs)})
+#@       output.append({"Name": config.ordererOrganizations[i].name, "OrdererEndpoints": orgOrderers(config.ordererOrganizations[i], port1, config), "ID": config.ordererOrganizations[i].mspId, "MSPDir": artifactsLocation+"crypto-config/ordererOrganizations/"+config.ordererOrganizations[i].name+"/msp", "Policies": orgPolicies(config.ordererOrganizations[i].mspId, "orderer", config.enableNodeOUs, "")})
 #@       port1 += config.ordererOrganizations[i].numOderers
 #@     end
 #@   end
 #@   if type == "peer":
 #@     port2 = 31000
+#@     capability = config.applicationCapabilities
 #@     for i in range(0, len(config.peerOrganizations)):
-#@       output.append({"Name": config.peerOrganizations[i].name, "AnchorPeers": anchorPeers(config.peerOrganizations[i].name, port2),"ID": config.peerOrganizations[i].mspId, "MSPDir": artifactsLocation+"crypto-config/peerOrganizations/"+config.peerOrganizations[i].name+"/msp", "Policies": orgPolicies(config.peerOrganizations[i].mspId, "peer", config.enableNodeOUs)})
+#@       output.append({"Name": config.peerOrganizations[i].name, "AnchorPeers": anchorPeers(config.peerOrganizations[i].name, port2),"ID": config.peerOrganizations[i].mspId, "MSPDir": artifactsLocation+"crypto-config/peerOrganizations/"+config.peerOrganizations[i].name+"/msp", "Policies": orgPolicies(config.peerOrganizations[i].mspId, "peer", config.enableNodeOUs, capability)})
 #@       port2 += config.peerOrganizations[i].numPeers
 #@     end
 #@   end
 #@   return output
 #@ end
-#@ def policies(type):
+
+#@ def policies(type, capability):
 #@   readers = {"Type": "ImplicitMeta", "Rule": "ANY Readers"}
 #@   writers = {"Type": "ImplicitMeta", "Rule": "ANY Writers"}
 #@   admins = {"Type": "ImplicitMeta", "Rule": "ANY Admins"}
 #@   output = {}
 #@   if type == "orderer":
 #@     blockValidation = {"Type": "ImplicitMeta", "Rule": "ANY Writers"}
-#@     output = {"Readers":readers, "Writers": writers, "Admins": admins, "BlockValidation": blockValidation}
+#@     output = {"Readers": readers, "Writers": writers, "Admins": admins, "BlockValidation": blockValidation}
 #@   else:
-#@     output = {"Readers":readers, "Writers": writers, "Admins": admins}
+#@     output = {"Readers": readers, "Writers": writers, "Admins": admins}
+#@     if capability == "V2_0":
+#@       endorsement = {"Type": "ImplicitMeta", "Rule": "ANY Endorsement"}
+#@       lifecycleendorsement = {"Type": "ImplicitMeta", "Rule": "ANY Endorsement"}
+#@       output = {"Readers": readers, "Writers": writers, "Admins": admins, "Endorsement": endorsement, "LifecycleEndorsement": lifecycleendorsement}
+#@     end
 #@   end
 #@   return output
 #@ end
+
 #@ def ordererHosts(config):
 #@   result = []
 #@   port1 = 30000
@@ -82,6 +101,7 @@
 #@   end
 #@   return result
 #@ end
+
 #@ def orderer(config):
 #@   result = {}
 #@   batch_size_options = config.orderer.batchSize
@@ -103,7 +123,7 @@
 #@       end
 #@     end
 #@     options = {"TickInterval": etcd_options.tickInterval, "ElectionTick": etcd_options.electionTick, "HeartbeatTick": etcd_options.heartbeatTick, "MaxInflightBlocks": etcd_options.maxInflightBlocks, "SnapshotIntervalSize": etcd_options.snapshotIntervalSize}
-#@     result = {"OrdererType": config.orderer.ordererType, "Addresses": ordererHosts(config), "BatchTimeout": config.orderer.batchTimeOut, "BatchSize": batchSize, "Organizations": organizations(config, "orderer"), "Policies": policies("orderer"), "Capabilities": config.ordererCapabilities, "EtcdRaft":{"Consenters":consenters, "Options":options}}
+#@     result = {"OrdererType": config.orderer.ordererType, "Addresses": ordererHosts(config), "BatchTimeout": config.orderer.batchTimeOut, "BatchSize": batchSize, "Organizations": organizations(config, "orderer"), "Policies": policies("orderer", ""), "Capabilities": capabilities(config.ordererCapabilities), "EtcdRaft":{"Consenters":consenters, "Options":options}}
 #@   elif (config.orderer.ordererType == "kafka"):
 #@     brokersList = []
 #@     kafka = {}
@@ -111,27 +131,33 @@
 #@       brokersList.append("kafka{}:9092".format(i))
 #@     end
 #@     kafka = {"Brokers": brokersList}
-#@     result = {"OrdererType": config.orderer.ordererType, "Addresses": ordererHosts(config), "BatchTimeout": config.orderer.batchTimeOut, "BatchSize": batchSize, "kafka": kafka, "Organizations": organizations(config, "orderer"),"Policies": policies("orderer"),"Capabilities": config.ordererCapabilities}
+#@     result = {"OrdererType": config.orderer.ordererType, "Addresses": ordererHosts(config), "BatchTimeout": config.orderer.batchTimeOut, "BatchSize": batchSize, "kafka": kafka, "Organizations": organizations(config, "orderer"),"Policies": policies("orderer", ""),"Capabilities": capabilities(config.ordererCapabilities)}
 #@   else:
-#@     result = {"OrdererType": config.orderer.ordererType, "Addresses": ordererHosts(config), "BatchTimeout": config.orderer.batchTimeOut, "BatchSize": batchSize, "Organizations": organizations(config, "orderer"), "Policies": policies("orderer"), "Capabilities": config.ordererCapabilities}
+#@     result = {"OrdererType": config.orderer.ordererType, "Addresses": ordererHosts(config), "BatchTimeout": config.orderer.batchTimeOut, "BatchSize": batchSize, "Organizations": organizations(config, "orderer"), "Policies": policies("orderer", ""), "Capabilities": capabilities(config.ordererCapabilities)}
 #@   end
 #@   return result
 #@ end
 
+#@ def capabilities(value):
+#@   output = []
+#@   output.append({value: "true"})
+#@   return output[0]
+#@ end
 #@ config = data.values
+
 Profiles:
   testorgschannel:
-    Policies: #@ policies("channel")
-    Capabilities: #@ config.channelCapabilities
+    Policies: #@ policies("channel", "")
+    Capabilities: #@ capabilities(config.channelCapabilities)
     Consortium: FabricConsortium
     Application:
       Organizations: #@ organizations(config, "peer")
-      Policies: #@ policies("peer")
-      Capabilities:  #@ config.applicationCapabilities
+      Policies: #@ policies("peer", config.applicationCapabilities)
+      Capabilities:  #@ capabilities(config.applicationCapabilities)
     Orderer: #@ orderer(config)
   testOrgsOrdererGenesis:
-    Policies: #@ policies("channel")
-    Capabilities: #@ config.channelCapabilities
+    Policies: #@ policies("channel", "")
+    Capabilities: #@ capabilities(config.channelCapabilities)
     Orderer: #@ orderer(config)
     Consortiums:
       FabricConsortium:

--- a/tools/operator/testdata/12hr80tps4org2chan-network-spec.yml
+++ b/tools/operator/testdata/12hr80tps4org2chan-network-spec.yml
@@ -80,14 +80,11 @@ peerOrganizations:
   numCa: 1
 
 #! Capabilites for Orderer, Channel, Application groups
-ordererCapabilities:
-  V2_0: true
+ordererCapabilities: V2_0
 
-channelCapabilities:
-  V2_0: true
+channelCapabilities: V2_0
 
-applicationCapabilities:
-  V1_4_2: true
+applicationCapabilities: V1_4_2
 
 #! Create the channel creation transactions; every org will be included in every channel
 #! This used testorgschannel as the prefix and channels are used like testorgschannel0,

--- a/tools/operator/testdata/barebones-network-spec.yml
+++ b/tools/operator/testdata/barebones-network-spec.yml
@@ -68,14 +68,11 @@ peerOrganizations:
   numCa: 1
 
 #! Capabilites for Orderer, Channel, Application groups
-ordererCapabilities:
-  V2_0: true
+ordererCapabilities: V2_0
 
-channelCapabilities:
-  V2_0: true
+channelCapabilities: V2_0
 
-applicationCapabilities:
-  V1_4_2: true
+applicationCapabilities: V1_4_2
 
 #! Create the channel creation transactions; every org will be included in every channel
 #! This used testorgschannel as the prefix and channels are used like testorgschannel0,

--- a/tools/operator/testdata/kafka-couchdb-tls-network-spec.yml
+++ b/tools/operator/testdata/kafka-couchdb-tls-network-spec.yml
@@ -80,14 +80,11 @@ peerOrganizations:
   numCa: 1
 
 #! Capabilites for Orderer, Channel, Application groups
-ordererCapabilities:
-  V2_0: true
+ordererCapabilities: V2_0
 
-channelCapabilities:
-  V2_0: true
+channelCapabilities: V2_0
 
-applicationCapabilities:
-  V1_4_2: true
+applicationCapabilities: V1_4_2
 
 #! Create the channel creation transactions; every org will be included in every channel
 #! This used testorgschannel as the prefix and channels are used like testorgschannel0,

--- a/tools/operator/testdata/kafka-leveldb-notls-network-spec.yml
+++ b/tools/operator/testdata/kafka-leveldb-notls-network-spec.yml
@@ -80,14 +80,11 @@ peerOrganizations:
   numCa: 1
 
 #! Capabilites for Orderer, Channel, Application groups
-ordererCapabilities:
-  V2_0: true
+ordererCapabilities: V2_0
 
-channelCapabilities:
-  V2_0: true
+channelCapabilities: V2_0
 
-applicationCapabilities:
-  V1_4_2: true
+applicationCapabilities: V1_4_2
 
 #! Create the channel creation transactions; every org will be included in every channel
 #! This used testorgschannel as the prefix and channels are used like testorgschannel0,

--- a/tools/operator/testdata/raft-couchdb-mutualtls-servdisc-network-spec.yml
+++ b/tools/operator/testdata/raft-couchdb-mutualtls-servdisc-network-spec.yml
@@ -72,14 +72,11 @@ peerOrganizations:
   numCa: 1
 
 #! Capabilites for Orderer, Channel, Application groups
-ordererCapabilities:
-  V2_0: true
+ordererCapabilities: V2_0
 
-channelCapabilities:
-  V2_0: true
+channelCapabilities: V2_0
 
-applicationCapabilities:
-  V1_4_2: true
+applicationCapabilities: V1_4_2
 
 #! Create the channel creation transactions; every org will be included in every channel
 #! This used testorgschannel as the prefix and channels are used like testorgschannel0,

--- a/tools/operator/testdata/smoke-network-spec.yml
+++ b/tools/operator/testdata/smoke-network-spec.yml
@@ -73,14 +73,11 @@ peerOrganizations:
   numCa: 1
 
 #! Capabilites for Orderer, Channel, Application groups
-ordererCapabilities:
-  V2_0: true
+ordererCapabilities: V2_0
 
-channelCapabilities:
-  V2_0: true
+channelCapabilities: V2_0
 
-applicationCapabilities:
-  V1_4_2: true
+applicationCapabilities: V1_4_2
 
 #! Create the channel creation transactions; every org will be included in every channel
 #! This used testorgschannel as the prefix and channels are used like testorgschannel0,


### PR DESCRIPTION
Operator to support new lifecycle policies and endorsement
policies when launching network with 2.0 application capabilities
enabled in 2.0 network.

Signed-off-by: Surya Lanka <suryalnvs@gmail.com>