### PR TITLE
[FAB-16345] Adding Command Option to operator

### DIFF
--- a/regression/smoke/smoke_test.go
+++ b/regression/smoke/smoke_test.go
@@ -42,24 +42,39 @@ var _ = Describe("Smoke Test Suite", func() {
 			err = testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("6) Sending Queries")
+			By("6) Printing Peer Logs")
+			action = "command"
+			err = testclient.Testclient(action, inputSpecPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("7) Sending Queries")
 			action = "query"
 			err = testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("7) Sending Invokes")
+			By("8) Sending Invokes")
 			action = "invoke"
 			err = testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("8) Upgrading Chaincode")
+			By("9) Printing Peer Logs")
+			action = "command"
+			err = testclient.Testclient(action, inputSpecPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("10) Upgrading Chaincode")
 			action = "upgrade"
 			err = testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("9) Sending Queries")
+			By("11) Sending Queries")
 			action = "query"
 			testclient.Testclient(action, inputSpecPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("12) Printing Peer Logs")
+			action = "command"
+			err = testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/regression/testdata/smoke-test-input.yml
+++ b/regression/testdata/smoke-test-input.yml
@@ -106,3 +106,19 @@ queries:
           constFreq: 0
           devFreq: 0
     args: "get,a1"
+
+command:
+  - name: curl
+    args:
+      - -H 
+      - 'Content-Type: application/json'
+      - -X
+      - PUT
+      - -d
+      - '{"spec":"info"}'
+      - http://127.0.0.1:31100/logspec
+    
+  - name: docker
+    args:
+      - logs
+      - peer0-org1

--- a/tools/operator/main.go
+++ b/tools/operator/main.go
@@ -148,6 +148,12 @@ func doAction(action, env, kubeConfigPath, inputFilePath string) error {
 		if err != nil {
 			return err
 		}
+	case "command":
+		err = testclient.Testclient("command", inputFilePath)
+		if err != nil {
+			logger.ERROR("Failed to execute command function")
+			return err
+		}
 	case "health":
 		switch env {
 		case "k8s":

--- a/tools/operator/testclient/inputStructs/structs.go
+++ b/tools/operator/testclient/inputStructs/structs.go
@@ -2,16 +2,17 @@ package inputStructs
 
 //Config --
 type Config struct {
-	OrdererSystemChannel string          `yaml:"ordererSystemChannel,omitempty"`
-	Organizations        []Organization  `yaml:"organizations,omitempty"`
-	CreateChannel        []Channel       `yaml:"createChannel,omitempty"`
-	AnchorPeerUpdate     []Channel       `yaml:"anchorPeerUpdate,omitempty"`
-	JoinChannel          []Channel       `yaml:"joinChannel,omitempty"`
-	InstallCC            []InstallCC     `yaml:"installChaincode,omitempty"`
-	InstantiateCC        []InstantiateCC `yaml:"instantiateChaincode,omitempty"`
-	UpgradeCC            []InstantiateCC `yaml:"upgradeChaincode,omitempty"`
-	Invoke               []InvokeQuery   `yaml:"invokes,omitempty"`
-	Query                []InvokeQuery   `yaml:"queries,omitempty"`
+	OrdererSystemChannel string           `yaml:"ordererSystemChannel,omitempty"`
+	Organizations        []Organization   `yaml:"organizations,omitempty"`
+	CreateChannel        []Channel        `yaml:"createChannel,omitempty"`
+	AnchorPeerUpdate     []Channel        `yaml:"anchorPeerUpdate,omitempty"`
+	JoinChannel          []Channel        `yaml:"joinChannel,omitempty"`
+	InstallCC            []InstallCC      `yaml:"installChaincode,omitempty"`
+	InstantiateCC        []InstantiateCC  `yaml:"instantiateChaincode,omitempty"`
+	UpgradeCC            []InstantiateCC  `yaml:"upgradeChaincode,omitempty"`
+	Invoke               []InvokeQuery    `yaml:"invokes,omitempty"`
+	Query                []InvokeQuery    `yaml:"queries,omitempty"`
+	CommandOptions       []CommandOptions `yaml:"command,omitempty"`
 }
 
 //Channel --
@@ -120,4 +121,10 @@ type CCOptions struct {
 type DiscoveryOptions struct {
 	Localhost bool `yaml:"localHost,omitempty"`
 	InitFreq  int  `yaml:"initFreq,omitempty"`
+}
+
+//CommandOptions --
+type CommandOptions struct {
+	Name string   `yaml:"name,omitempty"`
+	Args []string `yaml:"args,omitempty"`
 }

--- a/tools/operator/testclient/operations/executeCommand.go
+++ b/tools/operator/testclient/operations/executeCommand.go
@@ -1,0 +1,21 @@
+package operations
+
+import (
+	"github.com/hyperledger/fabric-test/tools/operator/networkclient"
+	"github.com/hyperledger/fabric-test/tools/operator/testclient/inputStructs"
+)
+
+//DoCommandAction --
+func DoCommandAction(config inputStructs.Config) error {
+
+	var err error
+	for index := 0; index < len(config.CommandOptions); index++ {
+		args := config.CommandOptions[index].Args
+		name := config.CommandOptions[index].Name
+		_, err = networkclient.ExecuteCommand(name, args, true)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/tools/operator/testclient/testclient.go
+++ b/tools/operator/testclient/testclient.go
@@ -43,7 +43,7 @@ func doAction(action string, config inputStructs.Config, testInputFilePath strin
 	var err error
 	var connectionProfileFileContents []byte
 	tls := "disabled"
-	supportedActions := "create|anchorpeer|join|install|instantiate|upgrade|invoke|query"
+	supportedActions := "create|anchorpeer|join|install|instantiate|upgrade|invoke|query|command"
 	if strings.HasSuffix(config.Organizations[0].ConnProfilePath, "yaml") || strings.HasSuffix(config.Organizations[0].ConnProfilePath, "yml") {
 		connectionProfileFileContents, err = ioutil.ReadFile(config.Organizations[0].ConnProfilePath)
 	} else {
@@ -88,6 +88,11 @@ func doAction(action string, config inputStructs.Config, testInputFilePath strin
 		case "invoke", "query":
 			var invokeQueryUIObject operations.InvokeQueryUIObject
 			err := invokeQueryUIObject.InvokeQuery(config, tls, strings.Title(action))
+			if err != nil {
+				return err
+			}
+		case "command":
+			err := operations.DoCommandAction(config)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Adding command option to operator to execute raw commands
when needed.
Usage: go run main.go -i testdata/smoke-test-input.yml -a command

Signed-off-by: Surya Lanka <suryalnvs@gmail.com>