### PR TITLE
[FAB-17550] Moving updateCapability, updatePolicy from upgradeNetwork

### DIFF
--- a/tools/operator/logger/logger.go
+++ b/tools/operator/logger/logger.go
@@ -20,6 +20,18 @@ func INFO(message ...string) {
 	info.Println(strings.Join(message, ""))
 }
 
+//WARNING -- To print the warning logs
+func WARNING(message ...string) {
+	warning := log.New(os.Stdout,
+		"WARNING: ",
+		log.Ldate|log.Ltime)
+	runTests, envVariableExists := os.LookupEnv("GinkoTests")
+	if envVariableExists && runTests == "true" {
+		warning.SetOutput(ginkgo.GinkgoWriter)
+	}
+	warning.Println(strings.Join(message, ""))
+}
+
 //ERROR -- To print the error logs
 func ERROR(message ...string) {
 	error := log.New(os.Stdout,

--- a/tools/operator/main.go
+++ b/tools/operator/main.go
@@ -48,7 +48,7 @@ func doAction(action, env, kubeConfigPath, inputFilePath string) error {
 	var err error
 	var inputPath string
 	var config networkspec.Config
-	actions := []string{"up", "down", "createChannelTxn", "migrate", "health", "upgradeNetwork", "networkInSync"}
+	actions := []string{"up", "down", "createChannelTxn", "migrate", "health", "upgradeNetwork", "networkInSync", "updateCapability", "updatePolicy"}
 	if contains(actions, action) {
 		contents, _ := ioutil.ReadFile(inputFilePath)
 		contents = append([]byte("#@data/values \n"), contents...)
@@ -57,7 +57,6 @@ func doAction(action, env, kubeConfigPath, inputFilePath string) error {
 
 		var network nl.Network
 		config, err = network.GetConfigData(inputPath)
-
 		if err != nil {
 			return err
 		}
@@ -80,6 +79,16 @@ func doAction(action, env, kubeConfigPath, inputFilePath string) error {
 		err = launcher.Launcher("upgradeNetwork", env, kubeConfigPath, inputPath)
 		if err != nil {
 			logger.ERROR("Failed to upgrade network")
+			return err
+		}
+	case "updateCapability":
+		err = launcher.Launcher("updateCapability", env, kubeConfigPath, inputPath)
+		if err != nil {
+			return err
+		}
+	case "updatePolicy":
+		err = launcher.Launcher("updatePolicy", env, kubeConfigPath, inputPath)
+		if err != nil {
 			return err
 		}
 	case "create":

--- a/tools/operator/scripts/upgradeNetwork.sh
+++ b/tools/operator/scripts/upgradeNetwork.sh
@@ -108,7 +108,7 @@ modifyAndSubmit(){
 
 upgradeDB(){
   setGlobals $1 $3 $4 peer
-  cd configFiles/backup/$2
+  cd $4/backup/$2
   export CORE_PEER_FILESYSTEMPATH=$PWD
   peer node upgrade-dbs
   cd -

--- a/tools/operator/templates/docker/docker-compose.yaml
+++ b/tools/operator/templates/docker/docker-compose.yaml
@@ -139,7 +139,7 @@
 #@       env.append("ORDERER_GENERAL_CLUSTER_CLIENTPRIVATEKEY=/etc/hyperledger/fabric/artifacts/msp/crypto-config/ordererOrganizations/{}/orderers/orderer{}-{}.{}/tls/server.key".format(org.name, j, org.name, org.name))
 #@       env.append("ORDERER_GENERAL_CLUSTER_CLIENTCERTIFICATE=/etc/hyperledger/fabric/artifacts/msp/crypto-config/ordererOrganizations/{}/orderers/orderer{}-{}.{}/tls/server.crt".format(org.name, j, org.name, org.name))
 #@       volumes = ["{}:/etc/hyperledger/fabric/artifacts/msp/".format(artifactsLocation)]
-#@       volumes.append("./backup/orderer{}-{}:/var/hyperledger/production/orderer".format(j, org.name))
+#@       volumes.append("{}/backup/orderer{}-{}:/var/hyperledger/production/orderer".format(artifactsLocation, j, org.name))
 #@       container_name = "orderer{}-{}".format(j,org.name)
 #@       image = "hyperledger/fabric-orderer:{}".format(config.fabricVersion)
 #@       if config.fabricVersion.endswith("-stable"):
@@ -195,7 +195,7 @@
 #@       container_name = "peer{}-{}".format(j, org.name)
 #@       volumes = ["{}:/etc/hyperledger/fabric/artifacts/msp/".format(artifactsLocation)]
 #@       volumes.append("/var/run/:/host/var/run/")
-#@       volumes.append("./backup/peer{}-{}:/var/hyperledger/production".format(j, org.name))
+#@       volumes.append("{}/backup/peer{}-{}:/var/hyperledger/production".format(artifactsLocation,j, org.name))
 #@       image = "hyperledger/fabric-peer:{}".format(config.fabricVersion)
 #@       if config.fabricVersion.endswith("-stable"):
 #@         env.append("CORE_CHAINCODE_BUILDER=hyperledger-fabric.jfrog.io/fabric-ccenv:amd64-{}".format(config.fabricVersion))


### PR DESCRIPTION
Split updateCapability and updatePolicy to be independent from
upgradeNetwork, such that while performing the rolling upgrades,
invokes can be sent at each step.

Signed-off-by: Surya Lanka <suryalnvs@gmail.com>