### PR TITLE
Use Pinned fabric-shim Version in Node Chaincode

### DIFF
--- a/chaincodes/samplecc/node/package.json
+++ b/chaincodes/samplecc/node/package.json
@@ -14,7 +14,7 @@
 	"license": "Apache-2.0",
 	"dependencies": {
 		"aes-js": "^3.1.0",
-		"fabric-shim": "unstable",
+		"fabric-shim": "latest",
 		"secure-random": "1.1.1"
 	}
 }


### PR DESCRIPTION
Fabric SDK Node no longer publishes the an unstable version of the shim package.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>