### PR TITLE
Fix Fabric CA Branch

### DIFF
--- a/ci/scripts/build/fabric-ca.sh
+++ b/ci/scripts/build/fabric-ca.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
-git clone -b ${BRANCH} https://github.com/hyperledger/fabric-ca "${GOPATH}/src/github.com/hyperledger/fabric-ca"
+git clone -b master https://github.com/hyperledger/fabric-ca "${GOPATH}/src/github.com/hyperledger/fabric-ca"
 cd "${GOPATH}/src/github.com/hyperledger/fabric-ca"
 make docker
 make release/linux-amd64


### PR DESCRIPTION
Fabric CA no longer follows the Fabric release cycle so we need to pull the master branch right now. We will revisit methodology in a later commit

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>