### PR TITLE
[FAB-17649] Allow the use of any Docker image

### DIFF
--- a/regression/testdata/12hr80tps4org2chan-network-spec.yml
+++ b/regression/testdata/12hr80tps4org2chan-network-spec.yml
@@ -2,11 +2,9 @@
 #!
 #! SPDX-License-Identifier: Apache-2.0
 ---
-#! fabricVersion:
-#! Released images are pulled from docker hub hyperledger/, e.g. 1.4.3 or 2.0.0
-#! Development stream images are pulled from
-#! nexus3.hyperledger.org:10001/hyperledger/, e.g. 1.4.3-stable or 2.0.0-stable
-fabricVersion: 2.1-stable
+dockerOrg: hyperledger-fabric.jfrog.io
+dockerTag: amd64-2.1-stable
+
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb
 #! This parameter is used to define fabric logging spec in peers

--- a/regression/testdata/barebones-network-spec.yml
+++ b/regression/testdata/barebones-network-spec.yml
@@ -3,11 +3,9 @@
 #! SPDX-License-Identifier: Apache-2.0
 
 ---
-#! fabricVersion:
-#! Released images are pulled from docker hub hyperledger/, e.g. 1.4.1 or 2.0.0
-#! Development stream images are pulled from
-#! hyperledger-fabric.jfrog.io/, e.g. 1.4.1-stable or 2.0.0-stable
-fabricVersion: 2.1-stable
+dockerOrg: hyperledger-fabric.jfrog.io
+dockerTag: amd64-2.1-stable
+
 #! peer database ledger type (couchdb, goleveldb)
 dbType: goleveldb
 #! This parameter is used to define fabric logging spec in peers

--- a/regression/testdata/basic-network-spec.yml
+++ b/regression/testdata/basic-network-spec.yml
@@ -3,7 +3,9 @@
 #! SPDX-License-Identifier: Apache-2.0
 
 ---
-fabricVersion: 2.1-stable
+dockerOrg: hyperledger-fabric.jfrog.io
+dockerTag: amd64-2.1-stable
+
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb
 #! This parameter is used to define fabric logging spec in peers

--- a/regression/testdata/kafka-couchdb-tls-network-spec.yml
+++ b/regression/testdata/kafka-couchdb-tls-network-spec.yml
@@ -2,11 +2,9 @@
 #!
 #! SPDX-License-Identifier: Apache-2.0
 ---
-#! fabricVersion:
-#! Released images are pulled from docker hub hyperledger/, e.g. 1.4.3 or 2.0.0
-#! Development stream images are pulled from
-#! hyperledger-fabric.jfrog.io/, e.g. 1.4.3-stable or 2.0.0-stable
-fabricVersion: 2.1-stable
+dockerOrg: hyperledger-fabric.jfrog.io
+dockerTag: amd64-2.1-stable
+
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb
 #! This parameter is used to define fabric logging spec in peers

--- a/regression/testdata/kafka-leveldb-notls-network-spec.yml
+++ b/regression/testdata/kafka-leveldb-notls-network-spec.yml
@@ -2,11 +2,9 @@
 #!
 #! SPDX-License-Identifier: Apache-2.0
 ---
-#! fabricVersion:
-#! Released images are pulled from docker hub hyperledger/, e.g. 1.4.1 or 2.0.0
-#! Development stream images are pulled from
-#! hyperledger-fabric.jfrog.io/, e.g. 1.4.1-stable or 2.0.0-stable
-fabricVersion: 2.1-stable
+dockerOrg: hyperledger-fabric.jfrog.io
+dockerTag: amd64-2.1-stable
+
 #! peer database ledger type (couchdb, goleveldb)
 dbType: goleveldb
 #! This parameter is used to define fabric logging spec in peers

--- a/regression/testdata/publish-network-spec.yml
+++ b/regression/testdata/publish-network-spec.yml
@@ -3,11 +3,9 @@
 #! SPDX-License-Identifier: Apache-2.0
 
 ---
-#! fabricVersion:
-#! Released images are pulled from docker hub hyperledger/, e.g. 1.4.1 or 2.0.0
-#! Development stream images are pulled from
-#! hyperledger-fabric.jfrog.io/, e.g. 1.4.1-stable or 2.0.0-stable
-fabricVersion: latest
+dockerOrg: hyperledger
+dockerTag: latest
+
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb
 #! This parameter is used to define fabric logging spec in peers

--- a/regression/testdata/raft-couchdb-mutualtls-servdisc-network-spec.yml
+++ b/regression/testdata/raft-couchdb-mutualtls-servdisc-network-spec.yml
@@ -2,11 +2,9 @@
 #!
 #! SPDX-License-Identifier: Apache-2.0
 ---
-#! fabricVersion:
-#! Released images are pulled from docker hub hyperledger/, e.g. 1.4.1 or 2.0.0
-#! Development stream images are pulled from
-#! hyperledger-fabric.jfrog.io/, e.g. 1.4.1-stable or 2.0.0-stable
-fabricVersion: 2.1-stable
+dockerOrg: hyperledger-fabric.jfrog.io
+dockerTag: amd64-2.1-stable
+
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb
 #! This parameter is used to define fabric logging spec in peers

--- a/regression/testdata/smoke-network-spec.yml
+++ b/regression/testdata/smoke-network-spec.yml
@@ -1,13 +1,10 @@
 #! Copyright IBM Corp. All Rights Reserved.
 #!
 #! SPDX-License-Identifier: Apache-2.0
-
 ---
-#! fabricVersion:
-#! Released images are pulled from docker hub hyperledger/, e.g. 1.4.1 or 2.0.0
-#! Development stream images are pulled from
-#! hyperledger-fabric.jfrog.io/, e.g. 1.4.1-stable or 2.0.0-stable
-fabricVersion: 2.1-stable
+dockerOrg: hyperledger-fabric.jfrog.io
+dockerTag: amd64-2.1-stable
+
 #! peer database ledger type (couchdb, goleveldb)
 dbType: goleveldb
 #! This parameter is used to define fabric logging spec in peers
@@ -94,7 +91,7 @@ k8s:
   #! persistent volumes. When false is used, backup will not be configured.
   #! When local is used, hostPath will be used to store the data from fabric containers
   #! to worker nodes on which pods are running.
-  dataPersistence: true
+  dataPersistence: false
   storageClass: default
   storageCapacity: 20Gi
   resources:

--- a/tools/operator/launcher/networkspec.yaml
+++ b/tools/operator/launcher/networkspec.yaml
@@ -2,11 +2,35 @@
 #!
 #! SPDX-License-Identifier: Apache-2.0
 ---
-#! fabricVersion:
-#! Released images are pulled from docker hub hyperledger/, e.g. 1.4.5 or 2.0.0
-#! Development stream images are pulled from
-#! hyperledger-fabric.jfrog.io/, e.g. 1.4.5-stable or 2.0.0-stable
-fabricVersion: 1.4.5-stable
+#! dockerOrg and dockerTag specify the organization name and image tag
+#! when pulling docker images. For example:
+#!
+#! dockerOrg: hyperledger-fabric.jfrog.io
+#! dockerTag: amd64-2.0-stable
+#!
+#! would pull the following seven fabric images:
+#!
+#! - hyperledger-fabric.jfrog.io/fabric-ca:amd64-2.0-stable
+#! - hyperledger-fabric.jfrog.io/fabric-peer:amd64-2.0-stable
+#! - hyperledger-fabric.jfrog.io/fabric-orderer:amd64-2.0-stable
+#! - hyperledger-fabric.jfrog.io/fabric-baseos:amd64-2.0-stable
+#! - hyperledger-fabric.jfrog.io/fabric-ccenv:amd64-2.0-stable
+#! - hyperledger-fabric.jfrog.io/fabric-javaenv:amd64-2.0-stable
+#! - hyperledger-fabric.jfrog.io/fabric-nodeenv:amd64-2.0-stable
+dockerOrg: hyperledger
+dockerTag: "2.0"
+
+#! dockerImages provides an override for each of the seven fabric images:
+#!
+#! ca, peer, orderer, baseos, ccenv, javaenv, nodeenv
+#!
+#! Specifying a full image name for any of thes values will take precedence over
+#! forming the image name using dockerOrg and dockerTag.
+#!
+#! dockerImages can be completely omitted if no override need be specified
+dockerImages:
+  ca: hyperledger/fabric-ca:1.4
+
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb
 #! This parameter is used to define fabric logging spec in peers

--- a/tools/operator/templates/docker/docker-compose.yaml
+++ b/tools/operator/templates/docker/docker-compose.yaml
@@ -5,6 +5,10 @@
 #@ load("@ytt:data", "data")
 #@ services = {}
 
+#@ def validateAttributeExists(config, image):
+#@   return hasattr(config, "dockerImages") and hasattr(config.dockerImages, image)
+#@ end
+
 #@ def caList(config):
 #@   caUniquePort = 32000
 #@   for i in range(0, len(config.peerOrganizations)):
@@ -39,9 +43,11 @@
 
 #@ def ca(container_name, caUniquePort, type, orgName, config):
 #@   orgType = "{}Organizations".format(type)
-#@   image = "hyperledger/fabric-ca:{}".format(config.fabricVersion)
-#@   if config.fabricVersion.endswith("-stable"):
-#@     image="hyperledger-fabric.jfrog.io/fabric-ca:amd64-{}".format(config.fabricVersion)
+#@   image = ""
+#@   if validateAttributeExists(config, "ca"):
+#@     image = config.dockerImages.ca
+#@   else:
+#@     image = "{}/fabric-ca:{}".format(config.dockerOrg, config.dockerTag)
 #@   end
 #@   env = ["FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server"]
 #@   env.append("FABRIC_CA_SERVER_CA_NAME={}".format(container_name))
@@ -141,9 +147,11 @@
 #@       volumes = ["{}:/etc/hyperledger/fabric/artifacts/msp/".format(artifactsLocation)]
 #@       volumes.append("{}/backup/orderer{}-{}:/var/hyperledger/production/orderer".format(artifactsLocation, j, org.name))
 #@       container_name = "orderer{}-{}".format(j,org.name)
-#@       image = "hyperledger/fabric-orderer:{}".format(config.fabricVersion)
-#@       if config.fabricVersion.endswith("-stable"):
-#@         image="hyperledger-fabric.jfrog.io/fabric-orderer:amd64-{}".format(config.fabricVersion)
+#@       image = ""
+#@       if validateAttributeExists(config, "orderer"):
+#@         image = config.dockerImages.orderer
+#@       else:
+#@         image = "{}/fabric-orderer:{}".format(config.dockerOrg, config.dockerTag)
 #@       end
 #@       ports = ["{}:{}".format(ordererUniquerPort,ordererUniquerPort), "{}:{}".format(ordererHealthCheckPort,8443)]
 #@       services[container_name] = {"image":image, "environment":env, "working_dir":"/opt/gopath/src/github.com/hyperledger/fabric", "command":"orderer", "volumes":volumes, "ports":ports, "container_name":container_name}
@@ -197,13 +205,31 @@
 #@       volumes = ["{}:/etc/hyperledger/fabric/artifacts/msp/".format(artifactsLocation)]
 #@       volumes.append("/var/run/:/host/var/run/")
 #@       volumes.append("{}/backup/peer{}-{}:/var/hyperledger/production".format(artifactsLocation,j, org.name))
-#@       image = "hyperledger/fabric-peer:{}".format(config.fabricVersion)
-#@       if config.fabricVersion.endswith("-stable"):
-#@         env.append("CORE_CHAINCODE_BUILDER=hyperledger-fabric.jfrog.io/fabric-ccenv:amd64-{}".format(config.fabricVersion))
-#@         env.append("CORE_CHAINCODE_GOLANG_RUNTIME=hyperledger-fabric.jfrog.io/fabric-baseos:amd64-{}".format(config.fabricVersion))
-#@         env.append("CORE_CHAINCODE_JAVA_RUNTIME=hyperledger-fabric.jfrog.io/fabric-javaenv:amd64-{}".format(config.fabricVersion))
-#@         env.append("CORE_CHAINCODE_NODE_RUNTIME=hyperledger-fabric.jfrog.io/fabric-nodeenv:amd64-{}".format(config.fabricVersion))
-#@         image="hyperledger-fabric.jfrog.io/fabric-peer:amd64-{}".format(config.fabricVersion)
+#@       image = ""
+#@       if validateAttributeExists(config, "peer"):
+#@         image = config.dockerImages.peer
+#@       else:
+#@         image = "{}/fabric-peer:{}".format(config.dockerOrg, config.dockerTag)
+#@       end
+#@       if validateAttributeExists(config, "ccenv"):
+#@         env.append("CORE_CHAINCODE_BUILDER={}".format(config.dockerImages.ccenv))
+#@       else:
+#@         env.append("CORE_CHAINCODE_BUILDER={}/fabric-ccenv:{}".format(config.dockerOrg, config.dockerTag))
+#@       end
+#@       if validateAttributeExists(config, "baseos"):
+#@         env.append("CORE_CHAINCODE_GOLANG_RUNTIME={}".format(config.dockerImages.baseos))
+#@       else:
+#@         env.append("CORE_CHAINCODE_GOLANG_RUNTIME={}/fabric-baseos:{}".format(config.dockerOrg, config.dockerTag))
+#@       end
+#@       if validateAttributeExists(config, "javaenv"):
+#@         env.append("CORE_CHAINCODE_JAVA_RUNTIME={}".format(config.dockerImages.javaenv))
+#@       else:
+#@         env.append("CORE_CHAINCODE_JAVA_RUNTIME={}/fabric-javaenv:{}".format(config.dockerOrg, config.dockerTag))
+#@       end
+#@       if validateAttributeExists(config, "nodeenv"):
+#@         env.append("CORE_CHAINCODE_NODEENV_RUNTIME={}".format(config.dockerImages.nodeenv))
+#@       else:
+#@         env.append("CORE_CHAINCODE_NODEENV_RUNTIME={}/fabric-nodeenv:{}".format(config.dockerOrg, config.dockerTag))
 #@       end
 #@       ports = ["7051", "{}:{}".format(peerUniquerPort,peerUniquerPort), "{}:{}".format(peerHealthCheckPort,9443)]
 #@       services[container_name] = {"image":image, "environment":env, "volumes":volumes, "ports":ports, "working_dir":"/opt/gopath/src/github.com/hyperledger/fabric/peer", "command":"peer node start", "container_name":container_name}

--- a/tools/operator/templates/k8s/fabric-k8s-pods.yaml
+++ b/tools/operator/templates/k8s/fabric-k8s-pods.yaml
@@ -3,6 +3,11 @@
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
+
+#@ def validateAttributeExists(config, image):
+#@   return hasattr(config, "dockerImages") and hasattr(config.dockerImages, image)
+#@ end
+
 #@ def zkContainers(input, id, zklist, config):
 #@   id = id + 1
 #@   env = [{ "name": "ZOO_MY_ID", "value": "{}".format(id)}]
@@ -60,9 +65,11 @@
 #@ end
 
 #@ def caContainers(input, orgName, config):
-#@   ca_image = "hyperledger/fabric-ca:{}".format(config.fabricVersion)
-#@   if config.fabricVersion.endswith("-stable"):
-#@     ca_image="hyperledger-fabric.jfrog.io/fabric-ca:amd64-{}".format(config.fabricVersion)
+#@   ca_image = ""
+#@   if validateAttributeExists(config, "ca"):
+#@     ca_image = config.dockerImages.ca
+#@   else:
+#@     ca_image = "{}/fabric-ca:{}".format(config.dockerOrg, config.dockerTag)
 #@   end
 #@   env = [{"name": "FABRIC_CA_HOME", "value": "/etc/hyperledger/fabric-ca-server"}]
 #@   env.append({"name": "FABRIC_CA_SERVER_CA_NAME", "value": "{}".format(input)})
@@ -157,13 +164,31 @@
 #@   end
 #@   resources = config.k8s.resources.peers
 #@   dindResources = config.k8s.resources.dind
-#@   peer_image = "hyperledger/fabric-peer:{}".format(config.fabricVersion)
-#@   if config.fabricVersion.endswith("-stable"):
-#@     env.append({"name": "CORE_CHAINCODE_BUILDER", "value": "hyperledger-fabric.jfrog.io/fabric-ccenv:amd64-{}".format(config.fabricVersion)})
-#@     env.append({"name": "CORE_CHAINCODE_GOLANG_RUNTIME", "value": "hyperledger-fabric.jfrog.io/fabric-baseos:amd64-{}".format(config.fabricVersion)})
-#@     env.append({"name": "CORE_CHAINCODE_JAVA_RUNTIME", "value": "hyperledger-fabric.jfrog.io/fabric-javaenv:amd64-{}".format(config.fabricVersion)})
-#@     env.append({"name": "CORE_CHAINCODE_NODE_RUNTIME", "value": "hyperledger-fabric.jfrog.io/fabric-nodeenv:amd64-{}".format(config.fabricVersion)})
-#@     peer_image="hyperledger-fabric.jfrog.io/fabric-peer:amd64-{}".format(config.fabricVersion)
+#@   peer_image = ""
+#@   if validateAttributeExists(config, "peer"):
+#@     peer_image = config.dockerImages.peer
+#@   else:
+#@     peer_image = "{}/fabric-peer:{}".format(config.dockerOrg, config.dockerTag)
+#@   end
+#@   if validateAttributeExists(config, "ccenv"):
+#@     env.append({"name": "CORE_CHAINCODE_BUILDER", "value": "{}".format(config.dockerImages.ccenv)})
+#@   else:
+#@     env.append({"name": "CORE_CHAINCODE_BUILDER", "value": "{}/fabric-ccenv:{}".format(config.dockerOrg, config.dockerTag)})
+#@   end
+#@   if validateAttributeExists(config, "baseos"):
+#@     env.append({"name": "CORE_CHAINCODE_GOLANG_RUNTIME", "value": "{}".format(config.dockerImages.baseos)})
+#@   else:
+#@     env.append({"name": "CORE_CHAINCODE_GOLANG_RUNTIME", "value": "{}/fabric-baseos:{}".format(config.dockerOrg, config.dockerTag)})
+#@   end
+#@   if validateAttributeExists(config, "javaenv"):
+#@     env.append({"name": "CORE_CHAINCODE_JAVA_RUNTIME", "value": "{}".format(config.dockerImages.javaenv)})
+#@   else:
+#@     env.append({"name": "CORE_CHAINCODE_JAVA_RUNTIME", "value": "{}/fabric-javaenv:{}".format(config.dockerOrg, config.dockerTag)})
+#@   end
+#@   if validateAttributeExists(config, "nodeenv"):
+#@     env.append({"name": "CORE_CHAINCODE_NODEENV_RUNTIME", "value": "{}".format(config.dockerImages.nodeenv)})
+#@   else:
+#@     env.append({"name": "CORE_CHAINCODE_NODEENV_RUNTIME", "value": "{}/fabric-nodeenv:{}".format(config.dockerOrg, config.dockerTag)})
 #@   end
 
 #@   if config.dbType == "couchdb":
@@ -221,9 +246,11 @@
 #@     volumeMounts.append({"mountPath": "/shared/data", "name": "orderer-data-storage"})
 #@   end
 #@   resources = config.k8s.resources.orderers
-#@   orderer_image = "hyperledger/fabric-orderer:{}".format(config.fabricVersion)
-#@   if config.fabricVersion.endswith("-stable"):
-#@     orderer_image="hyperledger-fabric.jfrog.io/fabric-orderer:amd64-{}".format(config.fabricVersion)
+#@   orderer_image = ""
+#@   if validateAttributeExists(config, "orderer"):
+#@     orderer_image = config.dockerImages.orderer
+#@   else:
+#@     orderer_image = "{}/fabric-orderer:{}".format(config.dockerOrg, config.dockerTag)
 #@   end
 #@   output = [{"name": input, "image": orderer_image, "imagePullPolicy": "Always", "env": env, "resources": resources, "volumeMounts": volumeMounts, "command": ["orderer"]}]
 #@   return output


### PR DESCRIPTION
Creates a new docker image definition methodology. Three config structs: dockerOrg, dockerTag, and dockerImages are provided. Users can specify a dockerOrg and a dockerTag and all seven (ca, peer, orderer, baseos, ccenv, javaenv, nodeenv) fabric images will be pulled using the specified org and tag.

The user can also specify each image manually using the dockerImages struct, or specify a subset of images to override the dockerOrg and dockerTag variables.

There are two three scenarios that can be configured now:

Scenario 1 - In this scenario all images are pulled from the same org and tag:
```
dockerOrg: hyperledger
dockerTag: 2.0.0
```

Scenario 2 - In this scenario all images except peer and orderer are pulled from the same org and tag. The peer and orderer are pulled from the specified location:
```
dockerOrg: hyperledger
dockerTag: 2.0.0
dockerImages:
  peer: hyperledger-fabric.jfrog.io/fabric-peer:amd64-2.0-stable
  orderer: exampleorg/fabric-orderer
```

Scenario 3 - In this scenario, all images are specified by the user and pulled from their specified location:
```
dockerImages:
  ca: hyperledger/fabric-ca:amd64-2.0.0
  peer: hyperledger-fabric.jfrog.io/fabric-peer:amd64-2.0-stable
  orderer: hyperledger/fabric-orderer:2.0.0
  baseos: hyperledger-fabric.jfrog.io/fabric-baseos:amd64-2.0-stable
  ccenv: testorg/fabric-ccenv:2.0-edge
  javaenv: hyperledger-fabric.jfrog.io/fabric-javaenv:amd64-2.0-stable
  nodeenv: hyperledger-fabric.jfrog.io/fabric-nodeenv:amd64-2.0-stable
```

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>