### PR TITLE
Update Prometheus Deployment

### DIFF
--- a/scripts/helm/prometheus/deploy.sh
+++ b/scripts/helm/prometheus/deploy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-helm install prometheus stable/prometheus
+helm install prometheus stable/prometheus -f values.yml

--- a/scripts/helm/prometheus/values.yml
+++ b/scripts/helm/prometheus/values.yml
@@ -1,0 +1,11 @@
+alertmanager:
+  enabled: false
+kubeStateMetrics:
+  enabled: false
+nodeExporter:
+  enabled: false
+pushgateway:
+  enabled: false
+server:
+  persistentVolume:
+    enabled: false


### PR DESCRIPTION
Disables unneeded Prometheus components, and remove the current PVC as there is a bug in the current helm chart related to PVC's no being able to be written to.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>