### PR TITLE
Remove 2.0 publishing

### DIFF
--- a/ci/scripts/build/fabric-chaincode-java.sh
+++ b/ci/scripts/build/fabric-chaincode-java.sh
@@ -4,9 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
-git clone -b ${BRANCH} https://github.com/hyperledger/fabric-chaincode-java "${GOPATH}/src/github.com/hyperledger/fabric-chaincode-java"
-cd "${GOPATH}/src/github.com/hyperledger/fabric-chaincode-java"
-./gradlew buildImage -x test
-
-# This is temporary until chaincode-java starts adding 2 digit tags
-docker tag hyperledger/fabric-javaenv hyperledger/fabric-javaenv:2.1
+docker pull hyperledger/fabric-javaenv:2.0
+docker tag hyperledger/fabric-javaenv:2.1 hyperledger/fabric-javaenv:2.1

--- a/ci/scripts/build/fabric-chaincode-node.sh
+++ b/ci/scripts/build/fabric-chaincode-node.sh
@@ -4,10 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
-git clone -b ${BRANCH} https://github.com/hyperledger/fabric-chaincode-node "${GOPATH}/src/github.com/hyperledger/fabric-chaincode-node"
-cd "${GOPATH}/src/github.com/hyperledger/fabric-chaincode-node"
-node common/scripts/install-run-rush.js install
-node common/scripts/install-run-rush.js rebuild
-
-# This is temporary until chaincode-node starts adding 2 digit tags
-docker tag hyperledger/fabric-nodeenv hyperledger/fabric-nodeenv:2.1
+docker pull hyperledger/fabric-nodeenv:2.0
+docker tag hyperledger/fabric-nodeenv:2.0 hyperledger/fabric-nodeenv:2.1

--- a/ci/scripts/trigger_publish_artifacts.sh
+++ b/ci/scripts/trigger_publish_artifacts.sh
@@ -6,11 +6,10 @@ set -uo pipefail
 
 docker login -u "${ARTIFACTORY_USERNAME}" -p "${ARTIFACTORY_PASSWORD}" hyperledger-fabric.jfrog.io
 
-for image in baseos peer orderer ccenv tools ca javaenv nodeenv; do
+for image in baseos peer orderer ccenv tools ca; do
     docker tag "hyperledger/fabric-${image}" "hyperledger-fabric.jfrog.io/fabric-${image}:amd64-${RELEASE}"
     docker push "hyperledger-fabric.jfrog.io/fabric-${image}:amd64-${RELEASE}"
 done
-
 
 for target in linux-amd64 darwin-amd64 windows-amd64; do
     cd "${GOPATH}/src/github.com/hyperledger/fabric"


### PR DESCRIPTION
Chaincode Node and Java no longer have release branches,
changes are now put into the next minor release

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>