### PR TITLE
Start 2.x publishing publishing

### DIFF
--- a/ci/azure-pipelines-nightly.yml
+++ b/ci/azure-pipelines-nightly.yml
@@ -27,9 +27,9 @@ variables:
   - name: GO_VER
     value: 1.13.8
   - name: NODE_VER
-    value: 10.17.0
+    value: 12.16.1
   - name: BRANCH
-    value: master
+    value: release-2.x
   - name: RELEASE
     value: 2.1-stable
 

--- a/ci/scripts/trigger_publish_artifacts.sh
+++ b/ci/scripts/trigger_publish_artifacts.sh
@@ -9,11 +9,7 @@ docker login -u "${ARTIFACTORY_USERNAME}" -p "${ARTIFACTORY_PASSWORD}" hyperledg
 for image in baseos peer orderer ccenv tools ca javaenv nodeenv; do
     docker tag "hyperledger/fabric-${image}" "hyperledger-fabric.jfrog.io/fabric-${image}:amd64-${RELEASE}"
     docker push "hyperledger-fabric.jfrog.io/fabric-${image}:amd64-${RELEASE}"
-
-    docker tag "hyperledger/fabric-${image}" "hyperledger-fabric.jfrog.io/fabric-${image}:amd64-latest"
-    docker push "hyperledger-fabric.jfrog.io/fabric-${image}:amd64-latest"
 done
-
 
 for target in linux-amd64 darwin-amd64 windows-amd64; do
     cd "${GOPATH}/src/github.com/hyperledger/fabric"


### PR DESCRIPTION
Release-2.1 is now built against release-2.x
in the chaincodes

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>