### PR TITLE
Enhance Lifecycle chaincode for multiple organizations of operator

### DIFF
--- a/ci/azure-pipelines-k8s.yml
+++ b/ci/azure-pipelines-k8s.yml
@@ -26,17 +26,15 @@ variables:
     value: 1.13.8
   - name: NODE_VER
     value: 10.x
-  - name: KUBE_PATH
-    value: $(kubeconfig.secureFilePath)
 
 stages:
-  - stage: Invokes
+  - stage: Longrun
     dependsOn: []
-    displayName: Invokes
+    displayName: Longrun
     pool:
       vmImage: ubuntu-18.04
     jobs:
-      - job: Longrun
+      - job: Invokes
         pool:
           vmImage: ubuntu-18.04
         timeoutInMinutes: 360
@@ -45,6 +43,33 @@ stages:
         - script: |
             cd tools/operator
             ARTIFACTORY_URL=https://hyperledger.jfrog.io/artifactory/fabric-test-artifacts/community-longrun.tar.gz
+            curl -sS -u ${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD} "${ARTIFACTORY_URL}" -o binaries.tgz
+            tar -xzvf binaries.tgz
+          env:
+            ARTIFACTORY_USERNAME: $(ARTIFACTORY_USERNAME)
+            ARTIFACTORY_PASSWORD: $(ARTIFACTORY_PASSWORD)
+          displayName: Download network artifacts
+        - script: make npm-init
+          displayName: Install NPM Packages
+        - script: |
+            cd tools/operator
+            go run main.go -i ../../regression/testdata/k8s-run-test.yml -a invoke
+          displayName: Invokes
+  - stage: Chaos
+    dependsOn: []
+    displayName: Chaos
+    pool:
+      vmImage: ubuntu-18.04
+    jobs:
+      - job: Invokes
+        pool:
+          vmImage: ubuntu-18.04
+        timeoutInMinutes: 360
+        steps:
+        - template: templates/install_deps.yml
+        - script: |
+            cd tools/operator
+            ARTIFACTORY_URL=https://hyperledger.jfrog.io/artifactory/fabric-test-artifacts/community-chaos.tar.gz
             curl -sS -u ${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD} "${ARTIFACTORY_URL}" -o binaries.tgz
             tar -xzvf binaries.tgz
           env:

--- a/regression/testdata/basic-test-input.yml
+++ b/regression/testdata/basic-test-input.yml
@@ -22,6 +22,7 @@ installChaincode:
     version: v1
     path: github.com/hyperledger/fabric-test/chaincodes/samplecc/go
     organizations: org1
+    targetPeers: peer0-org1
     language: golang
     metadataPath: ""
 
@@ -30,6 +31,7 @@ installChaincode:
     version: v1
     path: github.com/hyperledger/fabric-test/chaincodes/map_private/go
     organizations: org1
+    targetPeers: peer0-org1
     language: golang
     metadataPath: ""
 
@@ -38,6 +40,8 @@ instantiateChaincode:
     sdk: cli
     name: samplecc
     version: v1
+    sequence: 1
+    targetPeers: peer0-org1
     args: ""
     organizations: org1
     endorsementPolicy: 1of(org1)
@@ -47,6 +51,8 @@ instantiateChaincode:
     sdk: cli
     name: mapcc
     version: v1
+    sequence: 1
+    targetPeers: peer0-org1
     args: ""
     organizations: org1
     endorsementPolicy: 1of(org1)

--- a/regression/testdata/k8s-fabric-chaos-test-input.yml
+++ b/regression/testdata/k8s-fabric-chaos-test-input.yml
@@ -1,0 +1,28 @@
+organizations:
+  - name: org1
+    connProfilePath: ./connection-profile/connection_profile_org1.yaml
+  - name: org2
+    connProfilePath: ./connection-profile/connection_profile_org2.yaml
+
+command:
+  - name: helm
+    args:
+      - --namespace
+      - fabric-system-test
+      - install
+      - --set
+      - labels=type=orderer,namespaces=fabric-system-test,dryRun=false,rbac.create=true,interval=30m,minimumAge=60m
+      - --name
+      - chaos-orderer
+      - stable/chaoskube'
+  
+  - name: helm
+    args:
+      - install
+      - --namespace
+      - fabric-system-test
+      - --set
+      - labels=type=peer,namespaces=fabric-system-test,dryRun=false,rbac.create=true,interval=30m,minimumAge=60m
+      - --name
+      - chaos-peer
+      - stable/chaoskube

--- a/regression/testdata/k8s-run-test.yml
+++ b/regression/testdata/k8s-run-test.yml
@@ -24,7 +24,8 @@ joinChannel:
 installChaincode:
   - name: mapcc
     sdk: cli
-    version: v1
+    targetPeers: peer0-org1,peer0-org2,peer1-org1,peer1-org2
+    version: 1
     path: github.com/hyperledger/fabric-test/chaincodes/map_private/go
     organizations: org1,org2
     language: golang
@@ -33,12 +34,14 @@ installChaincode:
 instantiateChaincode:
   - channelName: testorgschannel0
     sdk: cli
+    sequence: 1
     name: mapcc
-    version: v1
+    version: 1
     args: ""
-    organizations: org1
+    organizations: org1,org2
+    targetPeers: peer0-org1,peer0-org2,peer1-org1,peer1-org2
     endorsementPolicy: 1of(org1, org2)
-    collectionPath: ../../regression/testdata/map-private-collections.json
+    collectionPath: ../../regression/testdata/map-private-collections-2orgs.json
 
 invokes:
   - channelName: testorgschannel0

--- a/regression/testdata/map-private-collections-2orgs.json
+++ b/regression/testdata/map-private-collections-2orgs.json
@@ -1,0 +1,9 @@
+[
+ {
+	 "name": "collectionSimple",
+	 "policy": "OR('Org1ExampleCom.peer','Org2ExampleCom.peer')",
+	 "requiredPeerCount": 0,
+	 "maxPeerCount": 0,
+	 "blockToLive": 0
+ }
+]

--- a/tools/operator/launcher/nl/network.go
+++ b/tools/operator/launcher/nl/network.go
@@ -24,10 +24,10 @@ type Network struct {
 //DockerImage --
 func DockerImage(component, dockerOrg, dockerTag, componentImage string) string {
 	var image string
-	if dockerOrg != "" {
-		image = fmt.Sprintf("%s/fabric-%s:%s", dockerOrg, component, dockerTag)
-	} else if componentImage != "" {
+	if componentImage != "" {
 		image = componentImage
+	} else if dockerOrg != "" {
+		image = fmt.Sprintf("%s/fabric-%s:%s", dockerOrg, component, dockerTag)
 	}
 	return image
 }

--- a/tools/operator/launcher/nl/network.go
+++ b/tools/operator/launcher/nl/network.go
@@ -23,13 +23,10 @@ type Network struct {
 
 //DockerImage --
 func DockerImage(component, dockerOrg, dockerTag, componentImage string) string {
-	var image string
 	if componentImage != "" {
-		image = componentImage
-	} else if dockerOrg != "" {
-		image = fmt.Sprintf("%s/fabric-%s:%s", dockerOrg, component, dockerTag)
+		return componentImage
 	}
-	return image
+	return fmt.Sprintf("%s/fabric-%s:%s", dockerOrg, component, dockerTag)
 }
 
 //GetConfigData - to read the yaml file and parse the data

--- a/tools/operator/testclient/inputStructs/structs.go
+++ b/tools/operator/testclient/inputStructs/structs.go
@@ -40,6 +40,7 @@ type InstallCC struct {
 	Organizations    string `yaml:"organizations,omitempty"`
 	Language         string `yaml:"language,omitempty"`
 	MetadataPath     string `yaml:"metadataPath,omitempty"`
+	TargetPeers      string `yaml:"targetPeers,omitempty"`
 }
 
 //InstantiateCC --
@@ -56,6 +57,8 @@ type InstantiateCC struct {
 	NumChannels       int            `yaml:"numChannels,omitempty"`
 	CollectionPath    string         `yaml:"collectionPath,omitempty"`
 	TimeOutOpt        TimeOutOptions `yaml:"timeoutOpt,omitempty"`
+	Sequence          string         `yaml:"sequence,omitempty"`
+	TargetPeers       string         `yaml:"targetPeers,omitempty"`
 }
 
 //TimeOutOptions --

--- a/tools/operator/testclient/operations/channelConfig.go
+++ b/tools/operator/testclient/operations/channelConfig.go
@@ -94,8 +94,19 @@ func (c ChannelUIObject) createChannelConfigObjects(orgNames []string, channelNa
 			action = "update"
 			channelTxPath = anchorPeerTxPath
 		}
-		channelOpt = ChannelOptions{Name: channelName, Action: action, OrgName: []string{orgName}, ChannelTX: channelTxPath}
-		c = ChannelUIObject{TransType: "Channel", TLS: tls, ConnProfilePath: paths.GetConnProfilePath([]string{orgName}, organizations), ChannelOpt: channelOpt, OrdererSystemChannel: ordererChannel}
+		channelOpt = ChannelOptions{
+			Name:      channelName,
+			Action:    action,
+			OrgName:   []string{orgName},
+			ChannelTX: channelTxPath,
+		}
+		c = ChannelUIObject{
+			TransType:            "Channel",
+			TLS:                  tls,
+			ConnProfilePath:      paths.GetConnProfilePath([]string{orgName}, organizations),
+			ChannelOpt:           channelOpt,
+			OrdererSystemChannel: ordererChannel,
+		}
 		channelObjects = append(channelObjects, c)
 	}
 	return channelObjects

--- a/tools/operator/testclient/operations/channelConfig.go
+++ b/tools/operator/testclient/operations/channelConfig.go
@@ -160,7 +160,7 @@ func (c ChannelUIObject) doChannelAction(channelUIObjects []ChannelUIObject) err
 		if err != nil {
 			return err
 		}
-		startTime := fmt.Sprintf("%s", time.Now())
+		startTime := time.Now().String()
 		args = []string{pteMainPath, strconv.Itoa(i), string(jsonObject), startTime}
 		wg.Add(1)
 		go c.channelConfig(channelObject.ChannelOpt.Action, channelObject.ChannelOpt.Name, args, &wg)

--- a/tools/operator/testclient/operations/channelConfig.go
+++ b/tools/operator/testclient/operations/channelConfig.go
@@ -3,11 +3,14 @@ package operations
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hyperledger/fabric-test/tools/operator/connectionprofile"
+	"github.com/hyperledger/fabric-test/tools/operator/logger"
 	"github.com/hyperledger/fabric-test/tools/operator/networkclient"
 	"github.com/hyperledger/fabric-test/tools/operator/paths"
 	"github.com/hyperledger/fabric-test/tools/operator/testclient/inputStructs"
@@ -123,23 +126,34 @@ func (c ChannelUIObject) createChannelObjectIfChanPrefix(channel inputStructs.Ch
 	return channelUIObjects
 }
 
+func (c ChannelUIObject) channelConfig(action, channelName string, args []string, wg *sync.WaitGroup) error {
+	defer wg.Done()
+	_, err := networkclient.ExecuteCommand("node", args, true)
+	if err != nil {
+		logger.ERROR(fmt.Sprintf("Failed to perform %s action on %s channel: %v", action, channelName, err))
+		os.Exit(1)
+	}
+	return nil
+}
+
 //doChannelAction -- To perform channel operations including create, anchorpeer update and join channel
 func (c ChannelUIObject) doChannelAction(channelUIObjects []ChannelUIObject) error {
 
 	var err error
 	var jsonObject []byte
+	var wg sync.WaitGroup
 	pteMainPath := paths.PTEPath()
-	for i := 0; i < len(channelUIObjects); i++ {
-		jsonObject, err = json.Marshal(channelUIObjects[i])
+	var args []string
+	for i, channelObject := range channelUIObjects {
+		jsonObject, err = json.Marshal(channelObject)
 		if err != nil {
 			return err
 		}
 		startTime := fmt.Sprintf("%s", time.Now())
-		args := []string{pteMainPath, strconv.Itoa(i), string(jsonObject), startTime}
-		_, err = networkclient.ExecuteCommand("node", args, true)
-		if err != nil {
-			return err
-		}
+		args = []string{pteMainPath, strconv.Itoa(i), string(jsonObject), startTime}
+		wg.Add(1)
+		go c.channelConfig(channelObject.ChannelOpt.Action, channelObject.ChannelOpt.Name, args, &wg)
 	}
+	wg.Wait()
 	return nil
 }

--- a/tools/operator/testclient/operations/installchaincode.go
+++ b/tools/operator/testclient/operations/installchaincode.go
@@ -127,21 +127,19 @@ func (i InstallCCUIObject) packageCC(installObject InstallCCUIObject) error {
 //installCCusingCLI -- installing cc using cli
 func (i InstallCCUIObject) installCCusingCLI(installObject InstallCCUIObject) error {
 
-	var connProfilePath string
-	for k := 0; k < len(installObject.ChannelOpt.OrgName); k++ {
-		orgName := installObject.ChannelOpt.OrgName[k]
+	for _, orgName := range installObject.ChannelOpt.OrgName {
 		currentDir, err := paths.GetCurrentDir()
 		if err != nil {
 			return err
 		}
+		var connProfilePath string
 		if strings.Contains(installObject.ConnProfilePath, ".yaml") || strings.Contains(installObject.ConnProfilePath, ".json") {
 			connProfilePath = installObject.ConnProfilePath
 		} else {
 			connProfilePath = fmt.Sprintf("%s/connection_profile_%s.yaml", installObject.ConnProfilePath, orgName)
 		}
-		for p := 0; p < len(installObject.TargetPeers); p++ {
-			peerName := installObject.TargetPeers[p]
-			peerOrgName := strings.Split(installObject.TargetPeers[p], "-")
+		for _, peerName := range installObject.TargetPeers {
+			peerOrgName := strings.Split(peerName, "-")
 			if peerOrgName[1] == orgName {
 				connProfConfig, err := GetConnProfileInformationForOrg(connProfilePath, orgName)
 				if err != nil {
@@ -173,8 +171,6 @@ func (i InstallCCUIObject) installCCusingCLI(installObject InstallCCUIObject) er
 				if err != nil {
 					return err
 				}
-			} else {
-				continue
 			}
 		}
 	}

--- a/tools/operator/testclient/operations/installchaincode.go
+++ b/tools/operator/testclient/operations/installchaincode.go
@@ -81,7 +81,7 @@ func (i InstallCCUIObject) createInstallCCObjects(ccObject inputStructs.InstallC
 func SetEnvForCLI(orgName, peerName, connProfilePath, tls, currentDir string) error {
 
 	var tlsNetwork string
-	connProfConfig, err := GetConnProfileInformationForOrg(connProfilePath, orgName)
+	connProfConfig, err := ConnProfileInformationForOrg(connProfilePath, orgName)
 	if err != nil {
 		return err
 	}
@@ -141,7 +141,7 @@ func (i InstallCCUIObject) installCCusingCLI(installObject InstallCCUIObject) er
 		for _, peerName := range installObject.TargetPeers {
 			peerOrgName := strings.Split(peerName, "-")
 			if peerOrgName[1] == orgName {
-				connProfConfig, err := GetConnProfileInformationForOrg(connProfilePath, orgName)
+				connProfConfig, err := ConnProfileInformationForOrg(connProfilePath, orgName)
 				if err != nil {
 					return err
 				}

--- a/tools/operator/testclient/operations/instantiatechaincode.go
+++ b/tools/operator/testclient/operations/instantiatechaincode.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -26,7 +27,9 @@ type InstantiateCCUIObject struct {
 	ConnProfilePath string                   `json:"ConnProfilePath,omitempty"`
 	ChannelOpt      ChannelOptions           `json:"channelOpt,omitempty"`
 	DeployOpt       InstantiateDeployOptions `json:"deploy,omitempty"`
-	TimeOutOpt      TimeOutOptions           `json:"timeoutOpt,timeoutOpt"`
+	TimeOutOpt      TimeOutOptions           `json:"timeoutOpt,omitempty"`
+	Sequence        string                   `json:"sequence,omitempty"`
+	TargetPeers     []string                 `json:"targetPeers,omitempty"`
 }
 
 //InstantiateDeployOptions --
@@ -62,11 +65,17 @@ type Identity struct {
 	} `json:"role,omitempty"`
 }
 
-//GetMSPID --
-type GetMSPID struct {
+//GetConnProfileOptions --
+type GetConnProfileOptions struct {
 	Organizations map[string]struct {
 		MSPID string `yaml:"mspid,omitempty"`
 	} `yaml:"organizations,omitempty"`
+	Peers map[string]struct {
+		URL string `json:"url,omitempty"`
+	} `yaml:"peers,omitempty"`
+	Orderers map[string]struct {
+		URL string `json:"url,omitempty"`
+	}
 }
 
 //InstalledCC --
@@ -130,10 +139,29 @@ func (i InstantiateCCUIObject) generateInstantiateCCObjects(ccObject inputStruct
 func (i InstantiateCCUIObject) createInstantiateCCObjects(orgNames []string, channelName, tls, action string, organizations []inputStructs.Organization, ccObject inputStructs.InstantiateCC) ([]InstantiateCCUIObject, error) {
 
 	var instantiateCCObjects []InstantiateCCUIObject
-	i = InstantiateCCUIObject{SDK: ccObject.SDK, TransType: action, TLS: tls, ConnProfilePath: paths.GetConnProfilePath(orgNames, organizations), ChainCodeID: ccObject.ChainCodeName, ChainCodeVer: ccObject.ChainCodeVersion}
-	i.ChannelOpt = ChannelOptions{Name: channelName, OrgName: orgNames}
-	i.DeployOpt = InstantiateDeployOptions{Function: ccObject.CCFcn, Arguments: strings.Split(ccObject.CCFcnArgs, ",")}
-	i.TimeOutOpt = TimeOutOptions{PreConfig: ccObject.TimeOutOpt.PreConfig, Request: ccObject.TimeOutOpt.Request}
+	targetPeers := strings.Split(ccObject.TargetPeers, ",")
+	i = InstantiateCCUIObject{
+		SDK:             ccObject.SDK,
+		TransType:       action,
+		TLS:             tls,
+		ConnProfilePath: paths.GetConnProfilePath(orgNames, organizations),
+		ChainCodeID:     ccObject.ChainCodeName,
+		ChainCodeVer:    ccObject.ChainCodeVersion,
+		TargetPeers:     targetPeers,
+		Sequence:        ccObject.Sequence,
+		ChannelOpt: ChannelOptions{
+			Name:    channelName,
+			OrgName: orgNames,
+		},
+		DeployOpt: InstantiateDeployOptions{
+			Function:  ccObject.CCFcn,
+			Arguments: strings.Split(ccObject.CCFcnArgs, ","),
+		},
+		TimeOutOpt: TimeOutOptions{
+			PreConfig: ccObject.TimeOutOpt.PreConfig,
+			Request:   ccObject.TimeOutOpt.Request,
+		},
+	}
 	if ccObject.TimeOutOpt.PreConfig == "" {
 		i.TimeOutOpt = TimeOutOptions{PreConfig: "600000", Request: "600000"}
 	}
@@ -184,10 +212,11 @@ func (i InstantiateCCUIObject) getEndorsementPolicy(organizations []inputStructs
 	for _, orgName := range orgNames {
 		orgName = strings.TrimSpace(orgName)
 		connProfilePath := paths.GetConnProfilePath([]string{orgName}, organizations)
-		mspID, err := GetMSPIDForOrg(connProfilePath, orgName)
+		connProfConfig, err := GetConnProfileInformationForOrg(connProfilePath, orgName)
 		if err != nil {
 			return endorsementPolicy, err
 		}
+		mspID := connProfConfig.Organizations[orgName].MSPID
 		identity.Role.Name = "member"
 		identity.Role.MSPID = mspID
 		identities = append(identities, identity)
@@ -208,15 +237,14 @@ func (i InstantiateCCUIObject) getEndorsementPolicy(organizations []inputStructs
 	return endorsementPolicy, nil
 }
 
-//GetMSPIDForOrg -- To get the MSP ID for an organization
-func GetMSPIDForOrg(connProfilePath, orgName string) (string, error) {
+//GetConnProfileInformationForOrg -- To get the MSP ID for an organization
+func GetConnProfileInformationForOrg(connProfilePath, orgName string) (GetConnProfileOptions, error) {
 
-	var config GetMSPID
-	var mspID string
+	var config GetConnProfileOptions
 	if !(strings.HasSuffix(connProfilePath, "yaml") || strings.HasSuffix(connProfilePath, "yml")) {
 		files, err := ioutil.ReadDir(connProfilePath)
 		if err != nil {
-			return "", err
+			return config, err
 		}
 		for _, file := range files {
 			if strings.Contains(file.Name(), orgName) {
@@ -228,42 +256,60 @@ func GetMSPIDForOrg(connProfilePath, orgName string) (string, error) {
 	yamlFile, err := ioutil.ReadFile(connProfilePath)
 	if err != nil {
 		logger.ERROR("Failed to read connectionprofile to get MSPID ")
-		return mspID, err
+		return config, err
 	}
 	err = yaml.Unmarshal(yamlFile, &config)
 	if err != nil {
-		logger.ERROR("Failed to create GetMSPID object")
-		return mspID, err
+		logger.ERROR("Failed to create GetConnProfileOptions object")
+		return config, err
 	}
-	mspID = config.Organizations[orgName].MSPID
-	return mspID, nil
+	return config, nil
+}
+
+func fetchOrdererInformation(currentDir string) ([]string, error) {
+
+	var ordererOrgPath string
+	var ordererDirectoryName string
+	var ordererName []string
+	files, err := ioutil.ReadDir(fmt.Sprintf("%s/crypto-config/ordererOrganizations/", currentDir))
+	if err != nil {
+		logger.ERROR("failed opening directory")
+		return ordererName, err
+	}
+	for _, file := range files {
+		ordererOrgPath = file.Name()
+		break
+	}
+	ordererDirectory, err := ioutil.ReadDir(fmt.Sprintf("%s/crypto-config/ordererOrganizations/%s/orderers/", currentDir, ordererOrgPath))
+	if err != nil {
+		logger.ERROR("failed opening directory")
+		return ordererName, err
+	}
+	for _, file := range ordererDirectory {
+		ordererDirectoryName = file.Name()
+		break
+	}
+	ordererName = strings.Split(ordererDirectoryName, ".")
+	return ordererName, nil
 }
 
 //queryInstalledusingCLI -- querying installed cc using cli
-func (i InstantiateCCUIObject) queryInstalledusingCLI(instantiateObject InstantiateCCUIObject) (InstalledCC, error) {
+func (i InstantiateCCUIObject) queryInstalledusingCLI(orgName, peerName, peerAddress, TLS string) (InstalledCC, error) {
 
-	queryInstalled := InstalledCC{}
-	orgName := instantiateObject.ChannelOpt.OrgName[0]
+	var queryInstalled InstalledCC
 	currentDir, err := paths.GetCurrentDir()
 	if err != nil {
 		return queryInstalled, err
 	}
-	err = SetEnvForCLI(orgName, instantiateObject.ConnProfilePath, instantiateObject.TLS, currentDir)
-	if err != nil {
-		return queryInstalled, err
-	}
-
 	args := []string{"lifecycle",
 		"chaincode",
 		"queryinstalled",
-		"--peerAddresses", "127.0.0.1:31000",
-		"--tlsRootCertFiles", fmt.Sprintf("%s/crypto-config/peerOrganizations/%s/peers/peer0-%s.%s/tls/ca.crt", currentDir, orgName, orgName, orgName),
-		// "--connectionProfile",
-		// instantiateObject.ConnProfilePath,
+		"--peerAddresses", peerAddress,
+		"--tlsRootCertFiles", fmt.Sprintf("%s/crypto-config/peerOrganizations/%s/peers/%s.%s/tls/ca.crt", currentDir, orgName, peerName, orgName),
 		"--output",
 		"json"}
 
-	if instantiateObject.TLS == "clientauth" {
+	if TLS == "clientauth" {
 		args = append(args, "--tls")
 	}
 	installedCC, err := networkclient.ExecuteCommand("peer", args, true)
@@ -281,80 +327,149 @@ func (i InstantiateCCUIObject) queryInstalledusingCLI(instantiateObject Instanti
 func (i InstantiateCCUIObject) approveCCusingCLI(instantiateObject InstantiateCCUIObject) error {
 
 	var packageID string
-	orgName := instantiateObject.ChannelOpt.OrgName[0]
-	currentDir, err := paths.GetCurrentDir()
-	if err != nil {
-		return err
-	}
-	err = SetEnvForCLI(orgName, instantiateObject.ConnProfilePath, instantiateObject.TLS, currentDir)
-	if err != nil {
-		return err
-	}
-	queryInstalled, _ := i.queryInstalledusingCLI(instantiateObject)
-	for j := 0; j < len(queryInstalled.CC); j++ {
-		if queryInstalled.CC[j].Label == fmt.Sprintf("%s_%s", instantiateObject.ChainCodeID, instantiateObject.ChainCodeVer) {
-			packageID = queryInstalled.CC[j].PackageID
-			break
+	var peerAddress string
+	var ordererAddress string
+	var connProfilePath string
+	for k := 0; k < len(instantiateObject.ChannelOpt.OrgName); k++ {
+		orgName := instantiateObject.ChannelOpt.OrgName[k]
+		currentDir, err := paths.GetCurrentDir()
+		if err != nil {
+			return err
+		}
+		if strings.Contains(instantiateObject.ConnProfilePath, ".yaml") || strings.Contains(instantiateObject.ConnProfilePath, ".json") {
+			connProfilePath = instantiateObject.ConnProfilePath
+		} else {
+			connProfilePath = fmt.Sprintf("%s/connection_profile_%s.yaml", instantiateObject.ConnProfilePath, orgName)
+		}
+		connProfConfig, err := GetConnProfileInformationForOrg(connProfilePath, orgName)
+		if err != nil {
+			return err
+		}
+		ordererName, err := fetchOrdererInformation(currentDir)
+		ordererURL, err := url.Parse(connProfConfig.Orderers[ordererName[0]].URL)
+		if err != nil {
+			logger.ERROR("Failed to get orderer url from connection profile")
+			return err
+		}
+		ordererAddress = ordererURL.Host
+		args := []string{
+			"lifecycle",
+			"chaincode",
+			"approveformyorg",
+			"--channelID", instantiateObject.ChannelOpt.Name,
+			"--name", instantiateObject.ChainCodeID,
+			"--version", instantiateObject.ChainCodeVer,
+			"--sequence", instantiateObject.Sequence,
+			"--waitForEvent",
+			"--orderer", ordererAddress,
+			"--cafile", fmt.Sprintf("%s/crypto-config/ordererOrganizations/%s/orderers/%s.%s/tls/ca.crt", currentDir, ordererName[1], ordererName[0], ordererName[1]),
+			// "--connectionProfile",
+			// instantiateObject.ConnProfilePath,
+		}
+		for p := 0; p < len(instantiateObject.TargetPeers); p++ {
+			peerName := instantiateObject.TargetPeers[p]
+			peerOrgName := strings.Split(instantiateObject.TargetPeers[p], "-")
+			if peerOrgName[1] == orgName {
+				peerURL, err := url.Parse(connProfConfig.Peers[peerName].URL)
+				if err != nil {
+					logger.ERROR("Failed to get peer url from connection profile")
+					return err
+				}
+				peerAddress = peerURL.Host
+				err = SetEnvForCLI(orgName, peerName, connProfilePath, instantiateObject.TLS, currentDir)
+				if err != nil {
+					return err
+				}
+				queryInstalled, _ := i.queryInstalledusingCLI(orgName, peerName, peerAddress, instantiateObject.TLS)
+				for j := 0; j < len(queryInstalled.CC); j++ {
+					if queryInstalled.CC[j].Label == fmt.Sprintf("%s_%s", instantiateObject.ChainCodeID, instantiateObject.ChainCodeVer) {
+						packageID = queryInstalled.CC[j].PackageID
+						break
+					}
+				}
+				args = append(args,
+					"--peerAddresses", peerAddress,
+					"--tlsRootCertFiles", fmt.Sprintf("%s/crypto-config/peerOrganizations/%s/peers/%s.%s/tls/ca.crt", currentDir, orgName, peerName, orgName),
+				)
+			} else {
+				continue
+			}
+		}
+		args = append(args, "--package-id", packageID)
+		if instantiateObject.TLS == "clientauth" {
+			args = append(args, "--tls")
+		}
+		if instantiateObject.DeployOpt.CollectionsConfigPath != "" {
+			args = append(args, "--collections-config", instantiateObject.DeployOpt.CollectionsConfigPath)
+		}
+		_, err = networkclient.ExecuteCommand("peer", args, true)
+		if err != nil {
+			return err
 		}
 	}
-
-	args := []string{"lifecycle",
-		"chaincode",
-		"approveformyorg",
-		"--channelID", instantiateObject.ChannelOpt.Name,
-		"--name", instantiateObject.ChainCodeID,
-		"--version", instantiateObject.ChainCodeVer,
-		"--package-id", packageID,
-		"--sequence", "1",
-		"--waitForEvent",
-		"--orderer", "127.0.0.1:30000",
-		"--cafile", fmt.Sprintf("%s/crypto-config/ordererOrganizations/ordererorg1/orderers/orderer0-ordererorg1.ordererorg1/tls/ca.crt", currentDir),
-		// "--connectionProfile",
-		// instantiateObject.ConnProfilePath,
-		"--peerAddresses", "127.0.0.1:31000",
-		"--tlsRootCertFiles", fmt.Sprintf("%s/crypto-config/peerOrganizations/%s/peers/peer0-%s.%s/tls/ca.crt", currentDir, orgName, orgName, orgName)}
-
-	if instantiateObject.TLS == "clientauth" {
-		args = append(args, "--tls")
-	}
-	if instantiateObject.DeployOpt.CollectionsConfigPath != "" {
-		args = append(args, "--collections-config", instantiateObject.DeployOpt.CollectionsConfigPath)
-	}
-	_, err = networkclient.ExecuteCommand("peer", args, true)
-	if err != nil {
-		return err
-	}
-	return err
+	return nil
 }
 
 //commitCCusingCLI -- committing cc using CLI
 func (i InstantiateCCUIObject) commitCCusingCLI(instantiateObject InstantiateCCUIObject) error {
 
+	var connProfilePath string
 	orgName := instantiateObject.ChannelOpt.OrgName[0]
+	if strings.Contains(instantiateObject.ConnProfilePath, ".yaml") || strings.Contains(instantiateObject.ConnProfilePath, ".json") {
+		connProfilePath = instantiateObject.ConnProfilePath
+	} else {
+		connProfilePath = fmt.Sprintf("%s/connection_profile_%s.yaml", instantiateObject.ConnProfilePath, orgName)
+	}
 	currentDir, err := paths.GetCurrentDir()
 	if err != nil {
 		return err
 	}
-	err = SetEnvForCLI(orgName, instantiateObject.ConnProfilePath, instantiateObject.TLS, currentDir)
+	connProfConfig, err := GetConnProfileInformationForOrg(connProfilePath, orgName)
 	if err != nil {
 		return err
 	}
-
+	ordererName, err := fetchOrdererInformation(currentDir)
+	ordererURL, err := url.Parse(connProfConfig.Orderers[ordererName[0]].URL)
+	if err != nil {
+		logger.ERROR("Failed to get orderer url from connection profile")
+		return err
+	}
+	ordererAddress := ordererURL.Host
 	args := []string{"lifecycle",
 		"chaincode",
 		"commit",
 		"--channelID", instantiateObject.ChannelOpt.Name,
 		"--name", instantiateObject.ChainCodeID,
 		"--version", instantiateObject.ChainCodeVer,
-		"--sequence", "1",
+		"--sequence", instantiateObject.Sequence,
 		"--waitForEvent",
-		"--orderer", "127.0.0.1:30000",
-		"--cafile", fmt.Sprintf("%s/crypto-config/ordererOrganizations/ordererorg1/orderers/orderer0-ordererorg1.ordererorg1/tls/ca.crt", currentDir),
+		"--orderer", ordererAddress,
+		"--cafile", fmt.Sprintf("%s/crypto-config/ordererOrganizations/%s/orderers/%s.%s/tls/ca.crt", currentDir, ordererName[1], ordererName[0], ordererName[1]),
 		// "--connectionProfile",
 		// instantiateObject.ConnProfilePath,
-		"--peerAddresses", "127.0.0.1:31000",
-		"--tlsRootCertFiles", fmt.Sprintf("%s/crypto-config/peerOrganizations/%s/peers/peer0-%s.%s/tls/ca.crt", currentDir, orgName, orgName, orgName)}
-
+	}
+	for p := 0; p < len(instantiateObject.TargetPeers); p++ {
+		peerName := instantiateObject.TargetPeers[p]
+		peerOrgName := strings.Split(instantiateObject.TargetPeers[p], "-")
+		if peerOrgName[1] == orgName {
+			peerURL, err := url.Parse(connProfConfig.Peers[peerName].URL)
+			if err != nil {
+				logger.ERROR("Failed to get peer url from connection profile")
+				return err
+			}
+			peerAddress := peerURL.Host
+			args = append(args,
+				"--peerAddresses", peerAddress,
+				"--tlsRootCertFiles", fmt.Sprintf("%s/crypto-config/peerOrganizations/%s/peers/%s.%s/tls/ca.crt", currentDir, orgName, peerName, orgName),
+			)
+			err = SetEnvForCLI(orgName, peerName, connProfilePath, instantiateObject.TLS, currentDir)
+			if err != nil {
+				return err
+			}
+		} else {
+			continue
+		}
+	}
 	if instantiateObject.TLS == "clientauth" {
 		args = append(args, "--tls")
 	}
@@ -365,7 +480,7 @@ func (i InstantiateCCUIObject) commitCCusingCLI(instantiateObject InstantiateCCU
 	if err != nil {
 		return err
 	}
-	return err
+	return nil
 }
 
 //instantiateCC -- To instantiate chaincode

--- a/tools/operator/testclient/operations/instantiatechaincode.go
+++ b/tools/operator/testclient/operations/instantiatechaincode.go
@@ -65,8 +65,8 @@ type Identity struct {
 	} `json:"role,omitempty"`
 }
 
-//GetConnProfileOptions --
-type GetConnProfileOptions struct {
+//ConnProfileOptions --
+type ConnProfileOptions struct {
 	Organizations map[string]struct {
 		MSPID string `yaml:"mspid,omitempty"`
 	} `yaml:"organizations,omitempty"`
@@ -212,7 +212,7 @@ func (i InstantiateCCUIObject) getEndorsementPolicy(organizations []inputStructs
 	for _, orgName := range orgNames {
 		orgName = strings.TrimSpace(orgName)
 		connProfilePath := paths.GetConnProfilePath([]string{orgName}, organizations)
-		connProfConfig, err := GetConnProfileInformationForOrg(connProfilePath, orgName)
+		connProfConfig, err := ConnProfileInformationForOrg(connProfilePath, orgName)
 		if err != nil {
 			return endorsementPolicy, err
 		}
@@ -237,10 +237,10 @@ func (i InstantiateCCUIObject) getEndorsementPolicy(organizations []inputStructs
 	return endorsementPolicy, nil
 }
 
-//GetConnProfileInformationForOrg -- To get the MSP ID for an organization
-func GetConnProfileInformationForOrg(connProfilePath, orgName string) (GetConnProfileOptions, error) {
+//ConnProfileInformationForOrg -- To get the MSP ID for an organization
+func ConnProfileInformationForOrg(connProfilePath, orgName string) (ConnProfileOptions, error) {
 
-	var config GetConnProfileOptions
+	var config ConnProfileOptions
 	if !(strings.HasSuffix(connProfilePath, "yaml") || strings.HasSuffix(connProfilePath, "yml")) {
 		files, err := ioutil.ReadDir(connProfilePath)
 		if err != nil {
@@ -260,7 +260,7 @@ func GetConnProfileInformationForOrg(connProfilePath, orgName string) (GetConnPr
 	}
 	err = yaml.Unmarshal(yamlFile, &config)
 	if err != nil {
-		logger.ERROR("Failed to create GetConnProfileOptions object")
+		logger.ERROR("Failed to create ConnProfileOptions object")
 		return config, err
 	}
 	return config, nil
@@ -328,7 +328,7 @@ func (i InstantiateCCUIObject) approveCCusingCLI(instantiateObject InstantiateCC
 		} else {
 			connProfilePath = fmt.Sprintf("%s/connection_profile_%s.yaml", instantiateObject.ConnProfilePath, orgName)
 		}
-		connProfConfig, err := GetConnProfileInformationForOrg(connProfilePath, orgName)
+		connProfConfig, err := ConnProfileInformationForOrg(connProfilePath, orgName)
 		if err != nil {
 			return err
 		}
@@ -408,7 +408,7 @@ func (i InstantiateCCUIObject) commitCCusingCLI(instantiateObject InstantiateCCU
 	if err != nil {
 		return err
 	}
-	connProfConfig, err := GetConnProfileInformationForOrg(connProfilePath, orgName)
+	connProfConfig, err := ConnProfileInformationForOrg(connProfilePath, orgName)
 	if err != nil {
 		return err
 	}
@@ -458,10 +458,7 @@ func (i InstantiateCCUIObject) commitCCusingCLI(instantiateObject InstantiateCCU
 		args = append(args, "--collections-config", instantiateObject.DeployOpt.CollectionsConfigPath)
 	}
 	_, err = networkclient.ExecuteCommand("peer", args, true)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 //instantiateCC -- To instantiate chaincode


### PR DESCRIPTION
This PR enables to pass multiple orgs while installing and instantiating
the chaincode using peer lifecycle chaincode.

Refer basic-test-input.yml on how to pass needed arguments.

Signed-off-by: Surya Lanka <suryalnvs@gmail.com>