### PR TITLE
Remove npm rebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,6 @@ pre-reqs: npm-init pull-binaries-fabric gotools
 .PHONY: npm-init
 npm-init:
 	cd $(CURDIR)/tools/PTE && npm install
-    ifeq ($(shell arch), i386)
-		cd $(CURDIR)/tools/PTE && npm rebuild 2>/dev/null
-    endif
 
 .PHONY: lint
 lint: gotools


### PR DESCRIPTION
The grpc native module no longer has build issues on Mac so rebuilding is no longer required.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>