### PR TITLE
Support CouchDB 3.1

### DIFF
--- a/regression/testdata/basic-network-spec.yml
+++ b/regression/testdata/basic-network-spec.yml
@@ -4,7 +4,7 @@
 
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
-dockerTag: amd64-2.1-stable
+dockerTag: amd64-2.2-stable
 
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb

--- a/regression/testdata/smoke-network-spec.yml
+++ b/regression/testdata/smoke-network-spec.yml
@@ -3,7 +3,7 @@
 #! SPDX-License-Identifier: Apache-2.0
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
-dockerTag: amd64-2.1-stable
+dockerTag: amd64-2.2-stable
 
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb

--- a/tools/operator/launcher/k8s/network.go
+++ b/tools/operator/launcher/k8s/network.go
@@ -99,7 +99,17 @@ func (k8s K8s) launchObject(nsConfig networkspec.Config) ([]LaunchConfig, error)
 				container = corev1.Container{
 					Name:      "couchdb",
 					Resources: k8s.resources(nsConfig.K8s.Resources.Couchdb),
-					Image:     "couchdb:2.3",
+					Image:     "couchdb:3.1",
+					Env: []corev1.EnvVar{
+						{
+							Name:  "COUCHDB_USER",
+							Value: "admin",
+						},
+						{
+							Name:  "COUCHDB_PASSWORD",
+							Value: "adminpw",
+						},
+					},
 				}
 				if nsConfig.K8s.DataPersistence == "true" || nsConfig.K8s.DataPersistence == "local" {
 					volumeMount := corev1.VolumeMount{MountPath: "/opt/couchdb/data", Name: "couchdb-data-storage"}

--- a/tools/operator/templates/docker/docker-compose.yaml
+++ b/tools/operator/templates/docker/docker-compose.yaml
@@ -35,7 +35,8 @@
 #@     org = config.peerOrganizations[i]
 #@     for j in range(0, org.numPeers):
 #@       container_name = "couchdb-peer{}-{}".format(j, org.name)
-#@       services[container_name] = {"container_name":container_name, "image":"couchdb:2.3", "ports":["{}:5984".format(couchDBUniquePort)]}
+#@       env = ["COUCHDB_USER=admin", "COUCHDB_PASSWORD=adminpw"]
+#@       services[container_name] = {"container_name":container_name, "environment":env, "image":"couchdb:3.1", "ports":["{}:5984".format(couchDBUniquePort)]}
 #@       couchDBUniquePort += 1
 #@     end
 #@   end
@@ -172,6 +173,8 @@
 #@     org = config.peerOrganizations[i]
 #@     for j in range(0, org.numPeers):
 #@       env = ["CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock", "FABRIC_LOGGING_SPEC={}".format(config.peerFabricLoggingSpec), "CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=configfiles_default"]
+#@         env.append("CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=admin")
+#@         env.append("CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=adminpw")
 #@       if config.gossipEnable == True:
 #@         env.append("CORE_PEER_GOSSIP_STATE_ENABLED=true")
 #@         env.append("CORE_PEER_GOSSIP_ORGLEADER=false")


### PR DESCRIPTION
Fabric 2.2 is dropped support for Couch 2.3 and now supports CouchDB 3.1. The only major change to this is that CouchDB 3.1 requires an admin username and password to be set at launch

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>