### PR TITLE
Update Artifactory and Docker Deps

### DIFF
--- a/regression/testdata/12hr80tps4org2chan-network-spec.yml
+++ b/regression/testdata/12hr80tps4org2chan-network-spec.yml
@@ -3,9 +3,9 @@
 #! SPDX-License-Identifier: Apache-2.0
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
-dockerTag: amd64-2.2-stable
+dockerTag: amd64-2.3-stable
 dockerImages:
-  ca: hyperledger/fabric-ca
+  ca: hyperledger/fabric-ca:1.4
 
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb

--- a/regression/testdata/barebones-network-spec.yml
+++ b/regression/testdata/barebones-network-spec.yml
@@ -4,9 +4,9 @@
 
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
-dockerTag: amd64-2.2-stable
+dockerTag: amd64-2.3-stable
 dockerImages:
-  ca: hyperledger/fabric-ca
+  ca: hyperledger/fabric-ca:1.4
 
 #! peer database ledger type (couchdb, goleveldb)
 dbType: goleveldb

--- a/regression/testdata/basic-network-spec.yml
+++ b/regression/testdata/basic-network-spec.yml
@@ -4,9 +4,9 @@
 
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
-dockerTag: amd64-2.2-stable
+dockerTag: amd64-2.3-stable
 dockerImages:
-  ca: hyperledger/fabric-ca
+  ca: hyperledger/fabric-ca:1.4
 
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb

--- a/regression/testdata/k8s-run-network-spec.yml
+++ b/regression/testdata/k8s-run-network-spec.yml
@@ -3,9 +3,9 @@
 #! SPDX-License-Identifier: Apache-2.0
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
-dockerTag: amd64-2.2-stable
+dockerTag: amd64-2.3-stable
 dockerImages:
-  ca: hyperledger/fabric-ca
+  ca: hyperledger/fabric-ca:1.4
 
 dbType: couchdb
 peerFabricLoggingSpec: error

--- a/regression/testdata/kafka-couchdb-tls-network-spec.yml
+++ b/regression/testdata/kafka-couchdb-tls-network-spec.yml
@@ -3,9 +3,9 @@
 #! SPDX-License-Identifier: Apache-2.0
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
-dockerTag: amd64-2.2-stable
+dockerTag: amd64-2.3-stable
 dockerImages:
-  ca: hyperledger/fabric-ca
+  ca: hyperledger/fabric-ca:1.4
 
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb

--- a/regression/testdata/kafka-leveldb-notls-network-spec.yml
+++ b/regression/testdata/kafka-leveldb-notls-network-spec.yml
@@ -3,9 +3,9 @@
 #! SPDX-License-Identifier: Apache-2.0
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
-dockerTag: amd64-2.2-stable
+dockerTag: amd64-2.3-stable
 dockerImages:
-  ca: hyperledger/fabric-ca
+  ca: hyperledger/fabric-ca:1.4
 
 #! peer database ledger type (couchdb, goleveldb)
 dbType: goleveldb

--- a/regression/testdata/raft-couchdb-mutualtls-servdisc-network-spec.yml
+++ b/regression/testdata/raft-couchdb-mutualtls-servdisc-network-spec.yml
@@ -3,9 +3,9 @@
 #! SPDX-License-Identifier: Apache-2.0
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
-dockerTag: amd64-2.2-stable
+dockerTag: amd64-2.3-stable
 dockerImages:
-  ca: hyperledger/fabric-ca
+  ca: hyperledger/fabric-ca:1.4
 
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb

--- a/regression/testdata/smoke-network-spec.yml
+++ b/regression/testdata/smoke-network-spec.yml
@@ -3,9 +3,9 @@
 #! SPDX-License-Identifier: Apache-2.0
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
-dockerTag: amd64-2.2-stable
+dockerTag: amd64-2.3-stable
 dockerImages:
-  ca: hyperledger/fabric-ca
+  ca: hyperledger/fabric-ca:1.4
 
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb


### PR DESCRIPTION
Add the actual CA docker tag as we no longer publish the latest tag to dockerhub.

Update the artifactory images to 2.3, as we now publish those releases.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>