### PR TITLE
Update Chaincode Installation to Use Absolute Paths

### DIFF
--- a/ci/scripts/interop/publish/fabric-binary.sh
+++ b/ci/scripts/interop/publish/fabric-binary.sh
@@ -14,7 +14,10 @@ for target in linux-amd64 darwin-amd64; do
     cp ../../sampleconfig/*yaml config
     tar -czvf "hyperledger-fabric-${target}-${RELEASE}.tar.gz" bin config
     curl -u"${ARTIFACTORY_USERNAME}":"${ARTIFACTORY_PASSWORD}" \
-		-T "hyperledger-fabric-${target}-${RELEASE}.tar.gz" \
-		"https://hyperledger.jfrog.io/hyperledger/fabric-binaries/hyperledger-fabric-${target}-${RELEASE}.tar.gz"
+		  -T "hyperledger-fabric-${target}-${RELEASE}.tar.gz" \
+		  "https://hyperledger.jfrog.io/hyperledger/fabric-binaries/hyperledger-fabric-${target}-${RELEASE}.tar.gz"
+		curl -u"${ARTIFACTORY_USERNAME}":"${ARTIFACTORY_PASSWORD}" \
+		  -T "hyperledger-fabric-${target}-${RELEASE}.tar.gz" \
+		  "https://hyperledger.jfrog.io/hyperledger/fabric-binaries/hyperledger-fabric-${target}-latest.tar.gz"
     popd
 done

--- a/regression/testdata/12hr80tps4org2chan-test-input.yml
+++ b/regression/testdata/12hr80tps4org2chan-test-input.yml
@@ -23,7 +23,7 @@ installChaincode:
   - name: samplecc
     sdk: cli
     version: v1
-    path: github.com/hyperledger/fabric-test/chaincodes/samplecc/go
+    path: chaincodes/samplecc/go
     organizations: org1,org2,org3,org4
     targetPeers: peer0-org1,peer1-org1,peer0-org2,peer1-org2,peer0-org3,peer1-org3,peer0-org4,peer1-org4
     language: golang

--- a/regression/testdata/barebones-test-input.yml
+++ b/regression/testdata/barebones-test-input.yml
@@ -20,7 +20,7 @@ installChaincode:
     version: v1
     sdk: cli
     targetPeers: peer0-org1
-    path: github.com/hyperledger/fabric-test/chaincodes/map_private/go
+    path: chaincodes/map_private/go
     organizations: org1
     language: golang
     metadataPath: ""

--- a/regression/testdata/basic-test-input.yml
+++ b/regression/testdata/basic-test-input.yml
@@ -20,7 +20,7 @@ installChaincode:
   - name: samplecc
     sdk: cli
     version: v1
-    path: github.com/hyperledger/fabric-test/chaincodes/samplecc/go
+    path: chaincodes/samplecc/go
     organizations: org1
     targetPeers: peer0-org1
     language: golang
@@ -29,7 +29,7 @@ installChaincode:
   - name: mapcc
     sdk: cli
     version: v1
-    path: github.com/hyperledger/fabric-test/chaincodes/map_private/go
+    path: chaincodes/map_private/go
     organizations: org1
     targetPeers: peer0-org1
     language: golang

--- a/regression/testdata/k8s-run-test.yml
+++ b/regression/testdata/k8s-run-test.yml
@@ -26,7 +26,7 @@ installChaincode:
     sdk: cli
     targetPeers: peer0-org1,peer0-org2,peer1-org1,peer1-org2
     version: 1
-    path: github.com/hyperledger/fabric-test/chaincodes/map_private/go
+    path: chaincodes/map_private/go
     organizations: org1,org2
     language: golang
     metadataPath: ""

--- a/regression/testdata/publish-test-input.yml
+++ b/regression/testdata/publish-test-input.yml
@@ -27,7 +27,7 @@ installChaincode:
   - name: chaincodeGo
     version: v1
     sdk: cli
-    path: github.com/hyperledger/fabric-test/chaincodes/samplecc/go
+    path: chaincodes/samplecc/go
     organizations: org1,org2
     targetPeers: peer0-org1,peer0-org2
     language: golang
@@ -36,7 +36,7 @@ installChaincode:
   - name: chaincodeJava
     version: v1
     sdk: cli
-    path: github.com/hyperledger/fabric-test/chaincodes/samplecc/java
+    path: chaincodes/samplecc/java
     organizations: org1,org2
     targetPeers: peer0-org1,peer0-org2
     language: java
@@ -45,7 +45,7 @@ installChaincode:
   - name: chaincodeNode
     version: v1
     sdk: cli
-    path: github.com/hyperledger/fabric-test/chaincodes/samplecc/node
+    path: chaincodes/samplecc/node
     organizations: org1,org2
     targetPeers: peer0-org1,peer0-org2
     language: node
@@ -54,7 +54,7 @@ installChaincode:
   - name: chaincodeGo
     version: v2
     sdk: cli
-    path: github.com/hyperledger/fabric-test/chaincodes/samplecc/go
+    path: chaincodes/samplecc/go
     organizations: org1,org2
     targetPeers: peer0-org1,peer0-org2
     language: golang
@@ -63,7 +63,7 @@ installChaincode:
   - name: chaincodeJava
     version: v2
     sdk: cli
-    path: github.com/hyperledger/fabric-test/chaincodes/samplecc/java
+    path: chaincodes/samplecc/java
     organizations: org1,org2
     targetPeers: peer0-org1,peer0-org2
     language: java
@@ -72,7 +72,7 @@ installChaincode:
   - name: chaincodeNode
     version: v2
     sdk: cli
-    path: github.com/hyperledger/fabric-test/chaincodes/samplecc/node
+    path: chaincodes/samplecc/node
     organizations: org1,org2
     targetPeers: peer0-org1,peer0-org2
     language: node

--- a/regression/testdata/samplejava-test-input.yml
+++ b/regression/testdata/samplejava-test-input.yml
@@ -13,7 +13,7 @@ installChaincode:
     version: v1
     sdk: cli
     targetPeers: peer0-org1,peer0-org2,peer0-org3,peer0-org4
-    path: github.com/hyperledger/fabric-test/chaincodes/samplecc/java
+    path: chaincodes/samplecc/java
     organizations: org1,org2,org3,org4
     language: java
     metadataPath: ""

--- a/regression/testdata/sbecc-test-input.yml
+++ b/regression/testdata/sbecc-test-input.yml
@@ -11,7 +11,7 @@ organizations:
 installChaincode:
   - name: sbecc
     version: v1
-    path: github.com/hyperledger/fabric-test/chaincodes/sbe/go
+    path: chaincodes/sbe/go
     organizations: org1,org2,org3,org4
     language: golang
     metadataPath: ""

--- a/regression/testdata/smoke-test-input.yml
+++ b/regression/testdata/smoke-test-input.yml
@@ -32,7 +32,7 @@ installChaincode:
   - name: samplecc
     sdk: cli
     version: v1
-    path: github.com/hyperledger/fabric-test/chaincodes/samplecc/go
+    path: chaincodes/samplecc/go
     organizations: org1,org2
     targetPeers: peer0-org1,peer0-org2
     language: golang
@@ -41,7 +41,7 @@ installChaincode:
   - name: samplecc
     sdk: cli
     version: v2
-    path: github.com/hyperledger/fabric-test/chaincodes/samplecc/go
+    path: chaincodes/samplecc/go
     organizations: org1,org2
     targetPeers: peer0-org1,peer0-org2
     language: golang

--- a/regression/testdata/systemtest-test-input.yml
+++ b/regression/testdata/systemtest-test-input.yml
@@ -22,14 +22,14 @@ joinChannel:
 installChaincode:
   - name: samplecc
     version: v1
-    path: github.com/hyperledger/fabric-test/chaincodes/samplecc/go
+    path: chaincodes/samplecc/go
     organizations: org1,org2,org3,org4
     language: golang
     metadataPath: ""
 
   - name: samplejs
     version: v1
-    path: github.com/hyperledger/fabric-test/chaincodes/samplecc/node
+    path: chaincodes/samplecc/node
     organizations: org1,org2,org3,org4
     language: node
     metadataPath: ""

--- a/tools/operator/testclient/operations/installchaincode.go
+++ b/tools/operator/testclient/operations/installchaincode.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -100,7 +101,6 @@ func SetEnvForCLI(orgName, peerName, connProfilePath, tls, currentDir string) er
 
 //packageCC -- package cc using cli
 func (i InstallCCUIObject) packageCC(installObject InstallCCUIObject) error {
-
 	currentDir, err := paths.GetCurrentDir()
 	if err != nil {
 		return err
@@ -110,17 +110,20 @@ func (i InstallCCUIObject) packageCC(installObject InstallCCUIObject) error {
 	if err != nil {
 		return err
 	}
+
+	relativePath := fmt.Sprintf("%s/../../%s", currentDir, installObject.DeployOpt.ChainCodePath)
+	chaincodePath, err := filepath.Abs(relativePath)
+	if err != nil {
+		return err
+	}
 	args := []string{"lifecycle",
 		"chaincode",
 		"package",
 		"cc.tgz",
-		"--path", installObject.DeployOpt.ChainCodePath,
+		"--lang", strings.ToLower(installObject.DeployOpt.Language),
+		"--path", chaincodePath,
 		"--label", fmt.Sprintf("%s_%s", installObject.ChainCodeID, installObject.ChainCodeVer)}
-
 	_, err = networkclient.ExecuteCommand("peer", args, true)
-	if err != nil {
-		return err
-	}
 	return err
 }
 


### PR DESCRIPTION
We mistakenly were using old peer binaries as they weren't being published to artifactory anymore under the latest tag. So the following functionality change went unnoticed:

The move to Go Modules in Fabric means the user must specify both a chaincode language and an absolute path for the chaincode location. GoPath's can no longer be used.

This functionality change was fixed in the Fabric doc as well.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>