### PR TITLE
Remove key that is no longer supported

### DIFF
--- a/images/orderer/orderer.yaml
+++ b/images/orderer/orderer.yaml
@@ -336,11 +336,6 @@ ChannelParticipation:
   # Channel participation API is enabled.
   Enabled: "false"
 
-  # Permanently remove storage resources when a channel is removed.
-  # Defines the default behavior of channel removal.
-  RemoveStorage: "false"
-
-
 ################################################################################
 #
 #   Consensus Configuration


### PR DESCRIPTION
This key is no longer supported and is breaking the HSM build which uses a static config file.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>