### PR TITLE
Enhance operator to support snapshot and join by snapshot

### DIFF
--- a/regression/smoke/smoke_test.go
+++ b/regression/smoke/smoke_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/hyperledger/fabric-test/tools/operator/testclient"
+	l "github.com/hyperledger/fabric-test/tools/operator/launcher"
 )
 
 var _ = Describe("Smoke Test Suite", func() {
@@ -13,9 +14,11 @@ var _ = Describe("Smoke Test Suite", func() {
 		var (
 			action        string
 			inputSpecPath string
+			networkSpecPath string
 		)
 		It("Running end to end (old cc lifecycle)", func() {
 			inputSpecPath = "../testdata/smoke-test-input.yml"
+			networkSpecPath = "../testdata/smoke-network-spec.yml"
 
 			By("1) Creating channel")
 			action = "create"
@@ -52,28 +55,48 @@ var _ = Describe("Smoke Test Suite", func() {
 			err = testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("8) Sending Invokes")
+			By("8) Snashot the ledger")
+			action = "snapshot"
+			err = testclient.Testclient(action, inputSpecPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("9) Sending Invokes")
 			action = "invoke"
 			err = testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("9) Printing Peer Logs")
+			By("10) Printing Peer Logs")
 			action = "command"
 			err = testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("10) Upgrading Chaincode")
+			By("11) Adding new peer to the network")
+			action = "addPeer"
+			err = l.Launcher(action, "docker", "", networkSpecPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("12) Upgrading Chaincode")
 			action = "upgrade"
 			err = testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("11) Sending Queries")
+			By("13) Sending Queries")
 			action = "query"
 			testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("12) Printing Peer Logs")
+			By("14) Printing Peer Logs")
 			action = "command"
+			err = testclient.Testclient(action, inputSpecPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("15) Join new peers using snapshot")
+			action = "joinBySnapshot"
+			err = testclient.Testclient(action, inputSpecPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("16) Sending Invokes")
+			action = "invoke"
 			err = testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/regression/testdata/basic-network-spec.yml
+++ b/regression/testdata/basic-network-spec.yml
@@ -67,6 +67,11 @@ peerOrganizations:
   numPeers: 1
   numCa: 1
 
+addPeer:
+- name: org1
+  mspId: Org1ExampleCom
+  numPeers: 1
+
 #! Capabilites for Orderer, Channel, Application groups
 ordererCapabilities: V2_0
 

--- a/regression/testdata/basic-test-input.yml
+++ b/regression/testdata/basic-test-input.yml
@@ -16,6 +16,19 @@ joinChannel:
   - channelName: testorgschannel0
     organizations: org1
 
+snapshotChannel:
+  - channelName: testorgschannel0
+    organizations: org1
+    targetPeers: peer0-org1
+    blockNumber: 
+    - 1
+
+joinChannelBySnapshot:
+  - channelName: testorgschannel0
+    organizations: org1
+    targetPeers: peer1-org1
+    snapshotPath: peer0-org1:1
+
 installChaincode:
   - name: samplecc
     sdk: cli

--- a/regression/testdata/smoke-network-spec.yml
+++ b/regression/testdata/smoke-network-spec.yml
@@ -71,6 +71,11 @@ peerOrganizations:
   numPeers: 1
   numCa: 1
 
+addPeer:
+- name: org1
+  mspId: Org1ExampleCom
+  numPeers: 1
+
 #! Capabilites for Orderer, Channel, Application groups
 ordererCapabilities: V2_0
 

--- a/regression/testdata/smoke-test-input.yml
+++ b/regression/testdata/smoke-test-input.yml
@@ -27,6 +27,23 @@ joinChannel:
     numChannels: 1
     organizations: org1,org2
 
+snapshotChannel:
+# snapshot channel for the channel at the given block number 
+  - channelName: testorgschannel0
+    organizations: org1
+    targetPeers: peer0-org1
+    blockNumber: 
+    - 10
+    - 20
+    - 30
+
+joinChannelBySnapshot:
+# join targetPeers to the channel using snapshot
+  - channelName: testorgschannel0
+    organizations: org1
+    targetPeers: peer1-org1
+    snapshotPath: peer0-org1:10
+
 installChaincode:
 # installs chaincode with specified name on all peers in listed organziations
   - name: samplecc
@@ -76,13 +93,13 @@ invokes:
     name: samplecc
     targetPeers: AllPeers
     nProcPerOrg: 2
-    nRequest: 10
+    nRequest: 50
     runDur: 0
     organizations: org1,org2
     txnOpt:
       - mode: constant
         options:
-          constFreq: 0
+          constFreq: 2000
           devFreq: 0
     queryCheck: 100
     eventOpt:
@@ -97,6 +114,12 @@ invokes:
       payLoadMin: 1024
       payLoadMax: 2048
     args: "put,a1,1"
+    snapshotOptions:
+      height:
+      - 10
+      queryFrequency: 100
+      snapshotPeer: peer0-org1
+      enabled: false
 
 queries:
   - channelName: testorgschannel0

--- a/tools/PTE/README.md
+++ b/tools/PTE/README.md
@@ -774,6 +774,13 @@ The user input file contains configuration parameters including chaincode defini
             "method": "UserDefined",
             "nOrderers": "3",
         },
+        "snapshot": {
+            "enabled":  true,
+            "height":  [100000, 200000, 300000],
+            "channelID":  "testchannel1",
+            "peerName":  "peer0-org1",
+            "queryFreq":  "10000"
+        },
         "timeoutOpt": {
             "preConfig": "200000",
             "request": "45000",
@@ -1016,6 +1023,12 @@ where:
          * **UserDefined**: the orderer defined in the `ordererID` in the Service Credentials File for each org is used for invoke transactions. Note this is the same orderer used for all admin transactions.
          * **RoundRobin**: an orderer from the orderer section of Service Credentials File is assigned to each thread in the round robin fashion
     * **nOrderers**: the number of orderers to participate in the transactions, if this number is greater than the number of orderers listed in the service credential json, then all orderers will participate in the transactions.  If this number is set to 0, then all orderers participate in the transactions. Default: 0.
+* **snapshot**: PTE will spawn off an additional process to poll the blockheight of the specified peer periodically.  Once the specified blockheight is reached or exceeded, PTE will stop all invoke transaction processes.
+    * **enabled**: snapshot enabled: true or false
+    * **height**: an array of blockheights
+    * **channelID**: the channel ID
+    * **peerName**: the peer to poll blockheight
+    * **queryFreq**: blockheight polling frequency, unit: ms. Default: 10,000 ms
 * **timeoutOpt**: timeout configuration
     * **preConfig**: The timeout for channel creation and join and chaincode installation and instantiation. Unit: ms. Default:200,000.
     * **request**: The timeout for proposal and transaction. Unit: ms. Default:45,000.

--- a/tools/PTE/pte-execRequest.js
+++ b/tools/PTE/pte-execRequest.js
@@ -105,7 +105,7 @@ var txCfgPtr;
 var txCfgTmp;
 if (fs.existsSync(uiFile)) {
     uiContent = testUtil.readConfigFileSubmitter(uiFile);
-    if (typeof (uiContent.txCfgPtr) === 'undefined') {
+    if (!uiContent.hasOwnProperty('txCfgPtr')) {
         txCfgTmp = uiFile;
     } else {
         txCfgTmp = uiContent.txCfgPtr;
@@ -129,7 +129,7 @@ var distOpt;
 
 var ccDfnPtr;
 var ccDfntmp;
-if (typeof (uiContent.ccDfnPtr) === 'undefined') {
+if (!uiContent.hasOwnProperty('ccDfnPtr')) {
     ccDfntmp = uiFile;
 } else {
     ccDfntmp = uiContent.ccDfnPtr;
@@ -161,7 +161,7 @@ logger.info('[Nid:chan:org:id=%d:%s:%s:%d pte-execRequest] channelOrgName.length
 var client = new hfc();
 var channel = client.newChannel(channelName);
 
-if ((typeof (txCfgPtr.eventOpt) !== 'undefined') && (typeof (txCfgPtr.eventOpt.type) !== 'undefined')) {
+if ((txCfgPtr.hasOwnProperty('eventOpt')) && (txCfgPtr.eventOpt.hasOwnProperty('type'))) {
     evtType = txCfgPtr.eventOpt.type.toUpperCase();
     if ((evtType != 'FILTEREDBLOCK') && (evtType != 'CHANNEL')) {
         logger.error('[Nid:chan:org:id=%d:%s:%s:%d pte-execRequest] unsupported event type: %s', Nid, channelName, org, pid, evtType);
@@ -169,12 +169,12 @@ if ((typeof (txCfgPtr.eventOpt) !== 'undefined') && (typeof (txCfgPtr.eventOpt.t
         process.exit(1);
     }
 }
-if ((typeof (txCfgPtr.eventOpt) !== 'undefined') && (typeof (txCfgPtr.eventOpt.timeout) !== 'undefined')) {
+if ((txCfgPtr.hasOwnProperty('eventOpt')) && (txCfgPtr.eventOpt.hasOwnProperty('timeout'))) {
     evtTimeout = txCfgPtr.eventOpt.timeout;
 }
 logger.info('[Nid:chan:org:id=%d:%s:%s:%d pte-execRequest] event type: %s, timeout: %d', Nid, channel.getName(), org, pid, evtType, evtTimeout);
 
-if (typeof (txCfgPtr.invokeCheck) !== 'undefined') {
+if (txCfgPtr.hasOwnProperty('invokeCheck')) {
     if (txCfgPtr.invokeCheck == 'TRUE') {
         invokeCheck = true;
     } else if (txCfgPtr.invokeCheck == 'FALSE') {
@@ -272,10 +272,8 @@ logger.info('[Nid:chan:org:id=%d:%s:%s:%d pte-execRequest] transMode: %s, transT
 
 // orderer parameters
 var ordererMethod = 'USERDEFINED';    // default method
-if (typeof (txCfgPtr.ordererOpt) !== 'undefined') {
-    if (typeof (txCfgPtr.ordererOpt.method) !== 'undefined') {
-        ordererMethod = txCfgPtr.ordererOpt.method.toUpperCase();
-    }
+if (txCfgPtr.hasOwnProperty('ordererOpt') && txCfgPtr.ordererOpt.hasOwnProperty('method')) {
+    ordererMethod = txCfgPtr.ordererOpt.method.toUpperCase();
 }
 logger.info('[Nid:chan:org:id=%d:%s:%s:%d pte-execRequest] input parameters: ordererMethod=%s', Nid, channelName, org, pid, ordererMethod);
 
@@ -291,7 +289,7 @@ var peerFOMethod = 'ROUNDROBIN';
 
 // failover is handled by SDK in discovery mode
 if (targetPeers != 'DISCOVERY') {
-    if (typeof (txCfgPtr.peerFailover) !== 'undefined') {
+    if (txCfgPtr.hasOwnProperty('peerFailover')) {
         if (txCfgPtr.peerFailover == 'TRUE') {
             peerFO = true;
         } else if (txCfgPtr.peerFailover == 'FALSE') {
@@ -300,7 +298,7 @@ if (targetPeers != 'DISCOVERY') {
             peerFO = txCfgPtr.peerFailover;
         }
     }
-    if (typeof (txCfgPtr.ordererFailover) !== 'undefined') {
+    if (txCfgPtr.hasOwnProperty('ordererFailover')) {
         if (txCfgPtr.ordererFailover == 'TRUE') {
             ordererFO = true;
         } else if (txCfgPtr.ordererFailover == 'FALSE') {
@@ -311,11 +309,11 @@ if (targetPeers != 'DISCOVERY') {
     }
 }
 if (peerFO) {
-    if (typeof (txCfgPtr.failoverOpt) !== 'undefined') {
-        if (typeof (txCfgPtr.failoverOpt.list) !== 'undefined') {
+    if (txCfgPtr.hasOwnProperty('failoverOpt')) {
+        if (txCfgPtr.failoverOpt.hasOwnProperty('list')) {
             peerFOList = txCfgPtr.failoverOpt.list.toUpperCase();
         }
-        if (typeof (txCfgPtr.failoverOpt.method) !== 'undefined') {
+        if (txCfgPtr.failoverOpt.hasOwnProperty('method')) {
             peerFOMethod = txCfgPtr.failoverOpt.method.toUpperCase();
         }
     }
@@ -340,13 +338,13 @@ logger.info('[Nid:chan:org:id=%d:%s:%s:%d pte-execRequest] runForever: %d', Nid,
 var timeoutOpt;
 var reqTimeout = 45000;     // default 45 sec
 var grpcTimeout = 3000;     // default 3 sec
-if ((typeof (txCfgPtr.timeoutOpt) !== 'undefined')) {
+if (txCfgPtr.hasOwnProperty('timeoutOpt')) {
     timeoutOpt = txCfgPtr.timeoutOpt;
     logger.info('main - timeoutOpt: %j', timeoutOpt);
-    if ((typeof (timeoutOpt.request) !== 'undefined')) {
+    if (timeoutOpt.hasOwnProperty('request')) {
         reqTimeout = parseInt(timeoutOpt.request);
     }
-    if ((typeof (timeoutOpt.grpcTimeout) !== 'undefined')) {
+    if (timeoutOpt.hasOwnProperty('grpcTimeout')) {
         grpcTimeout = parseInt(timeoutOpt.grpcTimeout);
         hfc.setConfigSetting('grpc-wait-for-ready-timeout', grpcTimeout);
     }
@@ -715,20 +713,20 @@ function setTargetPeers(tPeers) {
         testUtil.assignChannelPeersSubmitter(cpList, channel, client, tgtPeers, TLS, cpPath, evtType, invokeType, peerFOList, peerList, eventHubs);
     } else if ((tPeers == 'DISCOVERY') || (transType == 'DISCOVERY')) {
         serviceDiscovery = true;
-        if ((typeof (txCfgPtr.discoveryOpt) !== 'undefined')) {
+        if (txCfgPtr.hasOwnProperty('discoveryOpt')) {
             var discoveryOpt = txCfgPtr.discoveryOpt;
             logger.info('[Nid:chan:org:id=%d:%s:%s:%d setTargetPeers] discoveryOpt: %j', Nid, channelName, org, pid, discoveryOpt);
-            if ((typeof (discoveryOpt.localHost) !== 'undefined')) {
+            if (discoveryOpt.hasOwnProperty('localHost')) {
                 if (discoveryOpt.localHost == 'TRUE') {
                     localHost = true;
                 }
             }
-            if (typeof(discoveryOpt.collection) !== 'undefined') {
+            if (discoveryOpt.hasOwnProperty('collection')) {
                 endorsement_hint['chaincodes'] = [
                     {name: chaincode_id, collection_names: txCfgPtr.discoveryOpt.collection}
                 ];
             }
-            if ((typeof (discoveryOpt.initFreq) !== 'undefined')) {
+            if (discoveryOpt.hasOwnProperty('initFreq')) {
                 initFreq = parseInt(discoveryOpt.initFreq);
             }
         }
@@ -1055,8 +1053,8 @@ function eventRegisterFilteredBlock() {
                 clearTimeout(handle);
 
                 // this block listener handles the filtered block
-                if ((typeof (filtered_block.number) != 'undefined') && (filtered_block.number > 0)) {
-                    if (typeof (filtered_block.filtered_transactions) != 'undefined') {
+                if ((filtered_block.hasOwnProperty('number')) && (filtered_block.number > 0)) {
+                    if (filtered_block.hasOwnProperty('filtered_transactions')) {
                         for (i = 0; i < filtered_block.filtered_transactions.length; i++) {
                             var txid = filtered_block.filtered_transactions[i].txid;
                             if (txidList[txid]) {
@@ -1359,7 +1357,7 @@ function invoke_move_dist_evtBlock(backoffCalculator) {
                }
             }
 
-            if (typeof (results[0][0].response) === 'undefined') {
+            if (!results[0][0].hasOwnProperty('response')) {
                 reConnectEvtHub = 1;
                 tx_stats[tx_pFail]++;
                 logger.error('[Nid:chan:org:id=%d:%s:%s:%d invoke_move_dist_evtBlock] proposal failed %d, %j', Nid, channelName, org, pid, tx_stats[tx_pFail], tx_id.getTransactionID().toString());
@@ -1547,7 +1545,7 @@ function backoffCalculatorConstant() {
 function execModeConstant() {
     var freq = backoffCalculatorConstantFreq();
     if (transType == 'INVOKE') {
-        if (typeof (txCfgPtr.constantOpt.devFreq) == 'undefined') {
+        if (!txCfgPtr.constantOpt.hasOwnProperty('devFreq')) {
             logger.error('[Nid:chan:org:id=%d:%s:%s:%d execModeDistribution] devFreq undefined, set to 0', Nid, channelName, org, pid);
             devFreq = 0;
         } else {

--- a/tools/PTE/pte-snapshot.js
+++ b/tools/PTE/pte-snapshot.js
@@ -1,0 +1,304 @@
+/**
+ * Copyright 2016 IBM All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *   usage:
+ *    node pte-snapshot.js <Nid> <uiFile> <PTEid>
+ *       - Nid: Network id
+ *       - uiFile: user input file
+ *       - PTEid: PTE id
+ */
+'use strict';
+
+const child_process = require('child_process');
+let hfc = require('fabric-client');
+let fs = require('fs');
+let testUtil = require('./pte-util.js');
+
+// inputs
+let Nid = parseInt(process.argv[2]);
+let uiFile = process.argv[3];
+let PTEid = parseInt(process.argv[4]);
+PTEid = PTEid ? PTEid : 0
+let loggerMsg = 'PTE ' + PTEid + ' snapshot';
+let logger = new testUtil.PTELogger({ "prefix": loggerMsg, "level": "info" });
+logger.info('input parameters: Nid=%d, uiFile=%s, PTEid=%d', Nid, uiFile, PTEid);
+
+let txCfgPtr;
+let txCfgTmp;
+let uiContent;
+if (fs.existsSync(uiFile)) {
+    uiContent = testUtil.readConfigFileSubmitter(uiFile);
+
+    if (!uiContent.hasOwnProperty('txCfgPtr')) {
+        txCfgTmp = uiFile;
+    } else {
+        txCfgTmp = uiContent.txCfgPtr;
+    }
+    txCfgPtr = testUtil.readConfigFileSubmitter(txCfgTmp);
+}
+else {
+    uiContent = JSON.parse(uiFile)
+    txCfgPtr = uiContent;
+}
+
+let TLS = testUtil.setTLS(txCfgPtr);
+
+// snapshot input
+if (!txCfgPtr.hasOwnProperty('snapshot')) {
+    logger.error('snapshot input data is required');
+    process.exit(1);
+}
+let snapshot = txCfgPtr.snapshot;
+
+let isKube = false;
+if (snapshot.isKube ) {
+    isKube = snapshot.isKube;
+}
+let queryFreq = 10000;        // default query info frequency = 10 sec
+if (snapshot.hasOwnProperty('queryFreq')) {
+    queryFreq = parseInt(snapshot.queryFreq);
+}
+logger.info('snapshot query info frequency: %d', queryFreq);
+let heightArray = snapshot.height.sort((a, b) => a - b);
+logger.info('snapshot heightArray: ', heightArray);
+
+// find the connection profile
+let cpList = [];
+let cpPath = uiContent.ConnProfilePath;
+cpList = testUtil.getConnProfileListSubmitter(cpPath);
+if (cpList.length === 0) {
+    logger.error('error: invalid connection profile path or no connection profiles found in the connection profile path: %s', cpPath);
+    process.exit(1);
+}
+
+// find the org that contains the peer
+logger.info('snapshot: ', snapshot);
+let org = testUtil.findOrgnameFromPeerSubmitter(cpList, snapshot.peerName);
+let cpf = testUtil.findOrgConnProfileSubmitter(cpList, org);
+if (!cpf) {
+    logger.error('no connection profile is found for org(%s)', org);
+    process.exit(1);
+}
+let username = testUtil.getOrgEnrollIdSubmitter(cpf, org);
+let secret = testUtil.getOrgEnrollSecretSubmitter(cpf, org);
+
+// create client and channel objects
+let client = new hfc();
+let channel = client.newChannel(snapshot.channelID);
+
+// snapshot generation failure count
+let snapshotFailed = 0;
+
+// start queryinfo
+queryBlockInfoHandler(channel, client, org, cpf, queryFreq, isKube);
+
+/**
+ * poll snapshot generating or generated timestamp
+ *
+ * @param {string} cmd The generating or generated command
+ * @returns {object} The object contains the timestamp and status
+ */
+async function pollTimestamp(cmd) {
+
+    let t = 0;
+    let str;
+    let cmdStatus = true;
+    try {
+        str = (await child_process.execSync(cmd)).toString();
+        if (str.includes('[34m')) {
+            str = str.substr(str.indexOf('[34m')+4);
+        }
+        t = str.substr(0, str.indexOf('[kvledger]')-1);
+        t = new Date(t).getTime();
+    } catch(error) {
+        logger.warn('[pollTimestamp] command (%s) failed', cmd);
+        cmdStatus = false;
+    }
+
+    return {t, cmdStatus};
+}
+
+/**
+ * commands to fetch snapshot generation timestamps
+ *
+ * @param {string} peer The peer name
+ * @param {insteger} blk The block number
+ * @param {boolean} isKube The isKube environment
+ * @returns {object} The object of two commands to fetch snapshot generating and generated timestamps
+ */
+async function genTimeCmd(peer, blk, isKube) {
+
+    let cmd;
+
+    if (isKube) {
+        cmd = `kubectl logs ${peer}-0 -c ${peer} | grep snapshot`;
+    } else {
+        cmd = `docker logs ${peer} 2>&1 | grep snapshot`;
+    }
+
+    let subcmd1 = `${cmd} | grep Generating | grep =${blk}`;
+    let subcmd2 = `${cmd} | grep Generated | grep =${blk}`;
+
+    return {subcmd1, subcmd2};
+}
+
+/**
+ * get snapshot generation time
+ *
+ * @param {int} freq The snapshot generation time poll frequency
+ * @param {int} blk The block number of the snapshot generation time to be polled
+ * @param {boolean} isKube The isKube environment
+ * @returns {int} The integer: 0: failed, 1: succeeded, 2: in progress
+ */
+async function snapshotGenTime(freq, blk, isKube) {
+    let peer = snapshot.peerName;
+    let cmd = await genTimeCmd(peer, blk, isKube);
+
+    logger.info('[snapshotGenTime] Poll the snapshot generation time for block (%d) in peer (%s)', blk, peer);
+    let rtn = await pollTimestamp(cmd.subcmd1);
+    if (!rtn.cmdStatus) {
+        snapshotFailed ++;
+        if ( snapshotFailed >= 3 ) {
+            logger.warn('[snapshotGenTime] Poll snapshot generation time for block (%d) in peer (%s) failed (%d)', blk, peer, snapshotFailed);
+            snapshotFailed = 0;
+            return 0;
+        } else {
+            logger.info('[snapshotGenTime] Poll snapshot generating time for block (%d) in peer (%s) failed (%d), try again later', blk, peer, snapshotFailed);
+            return 2;
+        }
+    }
+    let t1 = rtn.t;
+
+    rtn = await pollTimestamp(cmd.subcmd2);
+    if (!rtn.cmdStatus) {
+        logger.info('[snapshotGenTime] The snapshot for block (%d) in peer (%s) is being generated ... ', blk, peer);
+        return 2;
+    }
+    let t2 = rtn.t;
+
+    // generate report
+    let snapshotRpt = 'snapshotReport.json';
+    let buff = {};
+    buff["peer"] = peer;
+    buff["height"] = blk;
+    buff["start"] = new Date(t1).toISOString();
+    buff["end"] = new Date(t2).toISOString();
+    buff["total(sec)"] = (t2-t1)/1000;
+
+    fs.appendFileSync(snapshotRpt, JSON.stringify(buff));
+    fs.appendFileSync(snapshotRpt, '\n');
+
+    snapshotFailed = 0;
+    logger.info('[snapshotGenTime] snapshot generation:', JSON.stringify(buff));
+
+    return 1;
+}
+
+/**
+ * query block info
+ *
+ * @param {object} channel The channel object
+ * @returns the block height
+ */
+async function queryBlockInfo(channel) {
+    const blockchainInfo = await channel.queryInfo();
+    logger.info('[queryBlockInfo] block height= %d', blockchainInfo.height);
+
+    return blockchainInfo.height;
+}
+
+/**
+ * query block info callback
+ *
+ * @param {object} channel The channel object
+ * @param {int} freq The query info frequency in ms
+ * @param {int} heightIdx The snapshot height index
+ * @param {boolean} isKube The isKube environment
+ * @returns {Promise<void>}
+ */
+async function queryBlockInfoCB(channel, freq, heightIdx, isKube) {
+
+    let blkheight = await queryBlockInfo(channel);
+    if ( parseInt(blkheight) > heightArray[heightIdx] ) {
+        logger.info('[queryBlockInfoCB] block height: target= %d, current= %d', heightArray[heightIdx], parseInt(blkheight));
+        // get snapshot generation time
+        let snapshotStatus = await snapshotGenTime(freq, heightArray[heightIdx], isKube);
+        if ( snapshotStatus === 1 || snapshotStatus === 0 ) {
+            heightIdx++;
+            if (heightIdx >= heightArray.length) {
+                logger.info('[queryBlockInfoCB] reach final block height: target= %d, current= %d', heightArray[heightIdx-1], parseInt(blkheight));
+                process.exit();
+            }
+        }
+    }
+
+    // schedule next query
+    return new Promise(function(resolve) {
+        setTimeout(function() {
+            queryBlockInfoCB(channel, freq, heightIdx, isKube);
+        }, freq);
+    });
+}
+
+/**
+ * query block info Handler
+ *
+ * @param {object} channel The channel object
+ * @param {object} client The client object
+ * @param {string} org The target organization name
+ * @param {string} cpf The connection profile contains the target org
+ * @param {int} freq The query info frequency in ms
+ * @param {boolean} isKube The isKube environment
+ * @returns {Promise<void>}
+ */
+async function queryBlockInfoHandler(channel, client, org, cpf, freq, isKube) {
+
+    // get client key if clientauth
+    if (TLS == testUtil.TLSCLIENTAUTH) {
+        await testUtil.tlsEnroll(client, org, cpf);
+        logger.debug('[queryBlockInfoHandler] got user private key: org= %s', org);
+    }
+
+
+    hfc.setConfigSetting('key-value-store', 'fabric-common/lib/impl/FileKeyValueStore.js');
+    let cryptoSuite = hfc.newCryptoSuite();
+    cryptoSuite.setCryptoKeyStore(hfc.newCryptoKeyStore({ path: testUtil.storePathForOrg(Nid, org) }));
+    client.setCryptoSuite(cryptoSuite);
+
+    testUtil.assignChannelOrdererSubmitter(channel, client, org, cpPath, TLS);
+
+    let tgtPeers = [];
+    tgtPeers[[org]]=[snapshot.peerName];
+    testUtil.assignChannelPeersSubmitter(cpList, channel, client, tgtPeers, TLS, cpPath, null, null, null, null, null);
+
+    let kvs = await hfc.newDefaultKeyValueStore({
+        path: testUtil.storePathForOrg(org)
+    })
+    await client.setStateStore(kvs);
+    await testUtil.getSubmitter(username, secret, client, true, Nid, org, cpf);
+    await channel.initialize();
+    logger.info('[queryBlockInfoHandler] successfully initialize channel');
+
+    try {
+        return await queryBlockInfoCB(channel, freq, 0, isKube);
+    } catch(err) {
+        logger.error('[queryBlockInfoHandler] initialize channel failed');
+        logger.error(err.stack ? err.stack : err);
+        process.exit(1);
+    }
+
+}

--- a/tools/operator/connectionprofile/updateconncectionprofile.go
+++ b/tools/operator/connectionprofile/updateconncectionprofile.go
@@ -38,6 +38,10 @@ func (c ConnProfile) updateConnectionProfilePerChannel(inputObject interface{}, 
 		channelName, channelPrefix, numChannels = configObject.ChannelName, configObject.ChannelPrefix, configObject.NumChannels
 		chainCodeID = fmt.Sprintf("%s:%s", configObject.ChainCodeName, configObject.ChainCodeVersion)
 		orgNames = strings.Split(configObject.Organizations, ",")
+	} else if action == "joinBySnapshot" {
+		configObject, _ := inputObject.(*inputStructs.JoinChannelBySnapshot)
+		channelName, channelPrefix, numChannels = configObject.ChannelName, configObject.ChannelPrefix, configObject.NumChannels
+		orgNames = strings.Split(configObject.Organizations, ",")
 	} else {
 		configObject, _ := inputObject.(*inputStructs.Channel)
 		channelName, channelPrefix, numChannels = configObject.ChannelName, configObject.ChannelPrefix, configObject.NumChannels
@@ -99,7 +103,7 @@ func (c ConnProfile) updateConnectionProfilePerOrg(organizations []inputStructs.
 		switch action {
 		case "create":
 			err = c.updateConnectionProfile(file, channelName, "orderer")
-		case "join":
+		case "join", "joinBySnapshot":
 			err = c.updateConnectionProfile(file, channelName, "peer")
 		case "instantiate", "upgrade":
 			err = c.updateConnectionProfile(file, channelName, "chaincodes", inputArgs[len(inputArgs)-1])

--- a/tools/operator/go.mod
+++ b/tools/operator/go.mod
@@ -3,6 +3,7 @@ module github.com/hyperledger/fabric-test/tools/operator
 go 1.14
 
 require (
+	github.com/docker/docker v1.4.2-0.20191101170500-ac7306503d23
 	github.com/fsouza/go-dockerclient v1.6.3
 	github.com/onsi/ginkgo v1.12.0
 	github.com/pkg/errors v0.9.1

--- a/tools/operator/launcher/k8s/extendNetwork.go
+++ b/tools/operator/launcher/k8s/extendNetwork.go
@@ -1,0 +1,132 @@
+package k8s
+
+import (
+	"fmt"
+
+	"github.com/hyperledger/fabric-test/tools/operator/fabricconfig"
+	"github.com/hyperledger/fabric-test/tools/operator/launcher/nl"
+	"github.com/hyperledger/fabric-test/tools/operator/logger"
+	"github.com/hyperledger/fabric-test/tools/operator/networkspec"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func (k8s K8s) extendLaunchObject(nsConfig networkspec.Config) ([]LaunchConfig, error) {
+
+	var launchConfig []LaunchConfig
+	coreConfig, err := fabricconfig.CoreConfig(nsConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read core config")
+	}
+
+	peerImage := nl.DockerImage("peer", nsConfig.DockerOrg, nsConfig.DockerTag, nsConfig.DockerImages.Peer)
+
+	var peerPort int32 = 31000
+	var peerMetricsPort int32 = 32000
+	for _, peerOrg := range nsConfig.PeerOrganizations {
+		peerPort = peerPort + int32(peerOrg.NumPeers)
+		peerMetricsPort = peerMetricsPort + int32(peerOrg.NumPeers)
+	}
+	for _, peerOrg := range nsConfig.PeerOrganizations {
+		var privileged bool = true
+		for _, org := range nsConfig.AddPeersToOrganization {
+			peerIndex := peerOrg.NumPeers
+			totalPeers := peerOrg.NumPeers + org.NumPeers
+			for j := peerIndex; j < totalPeers; j++ {
+				err := fabricconfig.GenerateCorePeerConfig(fmt.Sprintf("peer%d-%s", j, org.Name), org.Name, org.MSPID, nsConfig.ArtifactsLocation, peerPort, peerMetricsPort, coreConfig)
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to generate core configuration file")
+				}
+				containers := make([]corev1.Container, 0)
+				container := corev1.Container{
+					Name:            "dind",
+					Image:           "docker:dind",
+					ImagePullPolicy: corev1.PullPolicy("Always"),
+					Args:            []string{"dockerd", "-H tcp://0.0.0.0:2375", "-H unix://var/run/docker.sock"},
+					SecurityContext: &corev1.SecurityContext{Privileged: &privileged},
+					Resources:       k8s.resources(nsConfig.K8s.Resources.Dind),
+				}
+				containers = append(containers, container)
+				container = corev1.Container{
+					Name:            "peer",
+					Command:         []string{"peer"},
+					Args:            []string{"node", "start"},
+					Resources:       k8s.resources(nsConfig.K8s.Resources.Peers),
+					Image:           peerImage,
+					ImagePullPolicy: corev1.PullPolicy("Always"),
+					Env: []corev1.EnvVar{
+						{Name: "FABRIC_LOGGING_SPEC", Value: nsConfig.PeerFabricLoggingSpec},
+					},
+					VolumeMounts: k8s.volumeMountLists("peer", nsConfig.K8s.DataPersistence, nsConfig.EnableNodeOUs),
+				}
+				containers = append(containers, container)
+				l := LaunchConfig{
+					Name:       fmt.Sprintf("peer%d-%s", j, org.Name),
+					Type:       "peer",
+					Containers: containers,
+					Volumes:    k8s.volumesList("peer", org.Name, fmt.Sprintf("peer%d-%s", j, org.Name), nsConfig.K8s.DataPersistence, nsConfig.EnableNodeOUs),
+					Ports:      []int32{peerPort, peerMetricsPort},
+				}
+				launchConfig = append(launchConfig, l)
+				if nsConfig.DBType == "couchdb" {
+					c := LaunchConfig{
+						Name: fmt.Sprintf("couchdb-peer%d-%s", j, org.Name),
+						Type: "couchdb",
+					}
+					container = corev1.Container{
+						Name:            "couchdb",
+						Resources:       k8s.resources(nsConfig.K8s.Resources.Couchdb),
+						Image:           "couchdb:3.1",
+						ImagePullPolicy: corev1.PullPolicy("Always"),
+						Env: []corev1.EnvVar{
+							{
+								Name:  "COUCHDB_USER",
+								Value: "admin",
+							},
+							{
+								Name:  "COUCHDB_PASSWORD",
+								Value: "adminpw",
+							},
+						},
+					}
+					if nsConfig.K8s.DataPersistence == "true" || nsConfig.K8s.DataPersistence == "local" {
+						volumeMount := corev1.VolumeMount{MountPath: "/opt/couchdb/data", Name: "couchdb-data-storage"}
+						container.VolumeMounts = append(container.VolumeMounts, volumeMount)
+						volume := corev1.Volume{
+							Name: "couchdb-data-storage",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: fmt.Sprintf("couchdb-peer%d-%s-data", j, org.Name),
+								},
+							},
+						}
+						c.Volumes = []corev1.Volume{volume}
+					}
+					c.Containers = []corev1.Container{container}
+					launchConfig = append(launchConfig, c)
+				}
+				peerPort++
+				peerMetricsPort++
+			}
+		}
+	}
+	return launchConfig, nil
+}
+
+func (k8s K8s) extendLaunchNetwork(config networkspec.Config, clientset *kubernetes.Clientset) error {
+
+	launchConfig, err := k8s.extendLaunchObject(config)
+	if err != nil {
+		logger.ERROR("Failed to launch the fabric k8s components")
+		return err
+	}
+	for i := 0; i < len(launchConfig); i++ {
+		err = k8s.CreateStatefulset(launchConfig[i], config, clientset)
+		if err != nil {
+			logger.ERROR("Failed to launch the fabric k8s network")
+			return err
+		}
+	}
+	return nil
+}

--- a/tools/operator/launcher/k8s/network.go
+++ b/tools/operator/launcher/k8s/network.go
@@ -508,6 +508,42 @@ func (k8s K8s) Network(action string) error {
 			logger.ERROR("Failed to generate connection profile")
 			return err
 		}
+	case "addPeer":
+		err = network.ExtendConfigurationFiles("k8s")
+		if err != nil {
+			logger.ERROR("Failed to generate docker compose file")
+			return err
+		}
+		err = network.GenerateCryptoCerts(k8s.Config, "extend")
+		if err != nil {
+			logger.ERROR("Failed to generate certificates")
+			return err
+		}
+		clientset, err := k8s.buildClientset(kubeconfig)
+		if err != nil {
+			logger.ERROR("Failed to generate clientset for kubernetes")
+			return err
+		}
+		err = k8s.extendLaunchNetwork(k8s.Config, clientset)
+		if err != nil {
+			logger.ERROR("Failed to launch k8s fabric network")
+			return err
+		}
+		err = k8s.PodStatusCheck(k8s.Config.K8s.Namespace, clientset)
+		if err != nil {
+			logger.ERROR("Failed to verify fabric K8s pods state")
+			return err
+		}
+		err = k8s.CheckComponentsHealth(k8s.Config, clientset)
+		if err != nil {
+			logger.ERROR("Failed to check fabric K8s pods health")
+			return err
+		}
+		err = k8s.UpdateConnectionProfilesToAddNewPeers(k8s.Config, clientset)
+		if err != nil {
+			logger.ERROR("Failed to generate connection profile")
+			return err
+		}
 	case "down":
 		clientset, err := k8s.buildClientset(kubeconfig)
 		if err != nil {

--- a/tools/operator/launcher/nl/networkcleanup.go
+++ b/tools/operator/launcher/nl/networkcleanup.go
@@ -18,7 +18,7 @@ func (n Network) NetworkCleanUp(config networkspec.Config) error {
 
 	artifactsLocation := config.ArtifactsLocation
 	paths := []string{
-		paths.ConfigFilesDir(),
+		paths.ConfigFilesDir(false),
 		paths.JoinPath(paths.TemplatesDir(), "input.yaml"),
 		paths.ChannelArtifactsDir(artifactsLocation),
 		paths.CryptoConfigDir(artifactsLocation),

--- a/tools/operator/main.go
+++ b/tools/operator/main.go
@@ -46,7 +46,7 @@ func doAction(action, env, kubeConfigPath, inputFilePath string) error {
 	var err error
 	var inputPath string
 	var config networkspec.Config
-	actions := []string{"up", "down", "createChannelTxn", "migrate", "health", "upgradeNetwork", "networkInSync", "updateCapability", "updatePolicy", "upgradeDB"}
+	actions := []string{"up", "down", "createChannelTxn", "migrate", "health", "upgradeNetwork", "networkInSync", "updateCapability", "updatePolicy", "upgradeDB", "addPeer"}
 	if contains(actions, action) {
 		contents, _ := ioutil.ReadFile(inputFilePath)
 		contents = append([]byte("#@data/values \n"), contents...)
@@ -77,6 +77,12 @@ func doAction(action, env, kubeConfigPath, inputFilePath string) error {
 		err = launcher.Launcher("upgradeNetwork", env, kubeConfigPath, inputPath)
 		if err != nil {
 			logger.ERROR("Failed to upgrade network")
+			return err
+		}
+	case "addPeer":
+		err = launcher.Launcher("addPeer", env, kubeConfigPath, inputPath)
+		if err != nil {
+			logger.ERROR("Failed to add peers to network")
 			return err
 		}
 	case "upgradeDB":
@@ -113,6 +119,18 @@ func doAction(action, env, kubeConfigPath, inputFilePath string) error {
 			logger.ERROR("Failed to join peers to channel in network")
 			return err
 		}
+	case "joinBySnapshot":
+		err = testclient.Testclient("joinBySnapshot", inputFilePath)
+		if err != nil {
+			logger.ERROR("Failed to join peers to channel using snapshot in network")
+			return err
+		}
+	case "snapshot":
+		err = testclient.Testclient("snapshot", inputFilePath)
+		if err != nil {
+			logger.ERROR("Failed to create a snapshot on peer to channel in network")
+			return err
+		}
 	case "install":
 		err = testclient.Testclient("install", inputFilePath)
 		if err != nil {
@@ -144,7 +162,7 @@ func doAction(action, env, kubeConfigPath, inputFilePath string) error {
 			return err
 		}
 	case "createChannelTxn":
-		configTxnPath := paths.ConfigFilesDir()
+		configTxnPath := paths.ConfigFilesDir(false)
 		err = networkclient.GenerateChannelTransaction(config, configTxnPath)
 		if err != nil {
 			logger.ERROR("Failed to create channel transaction")

--- a/tools/operator/networkclient/createconfigtx.go
+++ b/tools/operator/networkclient/createconfigtx.go
@@ -12,7 +12,7 @@ import (
 func CreateConfigTxYaml() error {
 
 	var err error
-	configFilesDir := paths.ConfigFilesDir()
+	configFilesDir := paths.ConfigFilesDir(false)
 	configtxTemplatePath := paths.TemplateFilePath("configtx")
 	inputFilePath := paths.TemplateFilePath("input")
 	configtxPath := paths.ConfigFilePath("configtx")

--- a/tools/operator/networkclient/cryptogen.go
+++ b/tools/operator/networkclient/cryptogen.go
@@ -5,10 +5,15 @@ type Cryptogen struct {
 	Output     string
 }
 
-func (c Cryptogen) Args() []string {
-	return []string{
-		"generate",
+func (c Cryptogen) Args(action string) []string {
+	crytogenArgs := []string{
+		action,
 		"--config", c.ConfigPath,
-		"--output", c.Output,
 	}
+	if action == "extend" {
+		crytogenArgs = append(crytogenArgs, "--input", c.Output)
+	} else {
+		crytogenArgs = append(crytogenArgs, "--output", c.Output)
+	}
+	return crytogenArgs
 }

--- a/tools/operator/networkspec/structs.go
+++ b/tools/operator/networkspec/structs.go
@@ -27,6 +27,7 @@ type Config struct {
 	ArtifactsLocation        string                 `yaml:"artifactsLocation,omitempty"`
 	OrdererOrganizations     []OrdererOrganizations `yaml:"ordererOrganizations,omitempty"`
 	PeerOrganizations        []PeerOrganizations    `yaml:"peerOrganizations,omitempty"`
+	AddPeersToOrganization   []PeerOrganizations    `yaml:"addPeer,omitempty"`
 	Orderer                  struct {
 		OrdererType string `yaml:"ordererType,omitempty"`
 	} `yaml:"orderer,omitempty"`

--- a/tools/operator/paths/paths.go
+++ b/tools/operator/paths/paths.go
@@ -77,33 +77,46 @@ func ScriptsDir() string {
 
 //TemplateFilePath --
 func TemplateFilePath(fileName string) string {
-	templateFiles := map[string]string{"crypto-config": "crypto-config.yaml", "configtx": "configtx.yaml", "k8s": "k8s", "docker": "docker", "input": "input.yaml"}
+	templateFiles := map[string]string{
+		"crypto-config":        "crypto-config.yaml",
+		"crypto-config-extend": "crypto-config-extend.yaml",
+		"configtx":             "configtx.yaml",
+		"docker":               "docker/docker-compose.yaml",
+		"peer-extend":          "docker/peer-extend.yaml",
+		"input":                "input.yaml",
+	}
 	return JoinPath(TemplatesDir(), templateFiles[fileName])
 }
 
 //ConfigFilesDir --
-func ConfigFilesDir() string {
+func ConfigFilesDir(extend bool) string {
 	currentDir, err := GetCurrentDir()
 	if err != nil {
 		logger.ERROR("ConfigFilesDir function is failed in getting current directory")
 	}
+	configDirName := "configFiles"
 	if strings.Contains(currentDir, "regression") {
-		return componentPath(currentDir, "../../tools/operator/configFiles")
+		configDirName = "../../tools/operator/configFiles"
 	}
-	return componentPath(currentDir, "configFiles")
+	if extend {
+		configDirName = "configFiles/extend"
+		if strings.Contains(currentDir, "regression") {
+			configDirName = "../../tools/operator/configFiles/extend"
+		}
+	}
+	return componentPath(currentDir, configDirName)
 }
 
 //ConfigFilePath --
 func ConfigFilePath(fileName string) string {
 	configFiles := map[string]string{
-		"crypto-config": "crypto-config.yaml",
-		"configtx":      "configtx.yaml",
-		"docker":        "docker-compose.yaml",
-		"services":      "fabric-k8s-service.yaml",
-		"pods":          "fabric-k8s-pods.yaml",
-		"pvc":           "fabric-k8s-pvc.yaml",
+		"crypto-config":        "crypto-config.yaml",
+		"crypto-config-extend": "extend/crypto-config-extend.yaml",
+		"configtx":             "configtx.yaml",
+		"docker":               "docker-compose.yaml",
+		"peer-extend":          "extend/peer-extend.yaml",
 	}
-	return JoinPath(ConfigFilesDir(), configFiles[fileName])
+	return JoinPath(ConfigFilesDir(false), configFiles[fileName])
 }
 
 //GetCurrentDir --

--- a/tools/operator/templates/crypto-config-extend.yaml
+++ b/tools/operator/templates/crypto-config-extend.yaml
@@ -1,0 +1,31 @@
+#! Copyright IBM Corp. All Rights Reserved.
+#!
+#! SPDX-License-Identifier: Apache-2.0
+
+#@ load("@ytt:data", "data")
+#@ config = data.values
+#@ localIP = "127.0.0.1"
+PeerOrgs:
+#@ for j in range(0, len(config.peerOrganizations)):
+#@ for i in range(0, len(config.addPeer)):
+#@ if config.addPeer[i].name == config.peerOrganizations[j].name:
+#@   peerOrg = config.addPeer[i]
+- Domain: #@ peerOrg.name
+  Name: #@ peerOrg.name
+  EnableNodeOUs: #@ config.enableNodeOUs
+  Users:
+    Count: 1
+  Specs:
+  #@ for i in range(0, peerOrg.numPeers):
+  #@ peerNum = i + config.peerOrganizations[j].numPeers
+    - Hostname: #@ "peer{}-{}".format(peerNum, peerOrg.name)
+      SANS:
+        - #@ "{}".format(localIP) 
+    #@ if config.nodeportIP != "":
+        - #@ config.nodeportIP
+    #@ end
+  #@ end
+#@ end
+#@ end
+#@ end
+

--- a/tools/operator/templates/docker/peer-extend.yaml
+++ b/tools/operator/templates/docker/peer-extend.yaml
@@ -1,0 +1,155 @@
+#! Copyright IBM Corp. All Rights Reserved.
+#!
+#! SPDX-License-Identifier: Apache-2.0
+
+#@ load("@ytt:data", "data")
+#@ services = {}
+
+#@ def validateAttributeExists(config, image):
+#@   return hasattr(config, "dockerImages") and hasattr(config.dockerImages, image)
+#@ end
+
+#@ def couchDB(config):
+#@   totalPeers = 0
+#@   for k in range(0, len(config.peerOrganizations)):
+#@     totalPeers = totalPeers + config.peerOrganizations[k].numPeers
+#@   end
+#@   couchDBUniquePort = 33000 + totalPeers
+#@   for k in range(0, len(config.peerOrganizations)):
+#@     for i in range(0, len(config.addPeer)):
+#@     if config.addPeer[i].name == config.peerOrganizations[k].name:
+#@     org = config.addPeer[i]
+#@     for j in range(0, org.numPeers):
+#@       j = j + config.peerOrganizations[k].numPeers
+#@       container_name = "couchdb-peer{}-{}".format(j, org.name)
+#@       env = ["COUCHDB_USER=admin", "COUCHDB_PASSWORD=adminpw"]
+#@       services[container_name] = {"container_name":container_name, "environment":env, "image":"couchdb:3.1", "ports":["{}:5984".format(couchDBUniquePort)]}
+#@       couchDBUniquePort += 1
+#@     end
+#@     end
+#@     end
+#@   end
+#@ end
+
+#@ def mutualTLS(config):
+#@   output = []
+#@     for i in range(0, len(config.peerOrganizations)):
+#@       organization = config.peerOrganizations[i]
+#@       output.append("/etc/hyperledger/fabric/artifacts/msp/crypto-config/peerOrganizations/{}/ca/ca.{}-cert.pem".format(organization.name, organization.name))
+#@     end
+#@     for j in range(0, len(config.ordererOrganizations)):
+#@       organization = config.ordererOrganizations[j]
+#@       output.append("/etc/hyperledger/fabric/artifacts/msp/crypto-config/ordererOrganizations/{}/ca/ca.{}-cert.pem".format(organization.name, organization.name))
+#@     end
+#@   return output
+#@ end
+
+#@ def peers(config):
+#@   totalPeers = 0
+#@   for k in range(0, len(config.peerOrganizations)):
+#@     totalPeers = totalPeers + config.peerOrganizations[k].numPeers
+#@   end
+#@   for k in range(0, len(config.peerOrganizations)):
+#@     peerUniquerPort = 31000 + totalPeers
+#@     peerHealthCheckPort = 31100 + totalPeers
+#@     for i in range(0, len(config.addPeer)):
+#@     if config.addPeer[i].name == config.peerOrganizations[k].name:
+#@     org = config.addPeer[i]
+#@     for j in range(0, org.numPeers):
+#@       j = j + config.peerOrganizations[k].numPeers
+#@       env = ["CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock", "FABRIC_LOGGING_SPEC={}".format(config.peerFabricLoggingSpec), "CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=configfiles_default"]
+#@         env.append("CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=admin")
+#@         env.append("CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=adminpw")
+#@       if config.gossipEnable == True:
+#@         env.append("CORE_PEER_GOSSIP_STATE_ENABLED=true")
+#@         env.append("CORE_PEER_GOSSIP_ORGLEADER=false")
+#@         env.append("CORE_PEER_GOSSIP_USELEADERELECTION=true")
+#@       else:
+#@         env.append("CORE_PEER_GOSSIP_STATE_ENABLED=false")
+#@         env.append("CORE_PEER_GOSSIP_ORGLEADER=true")
+#@         env.append("CORE_PEER_GOSSIP_USELEADERELECTION=false")
+#@       end
+#@       env.append("CORE_PEER_GOSSIP_BOOTSTRAP=127.0.0.1:{}".format(peerUniquerPort))
+#@       env.append("CORE_PEER_GOSSIP_ENDPOINT=peer{}-{}:{}".format(j, org.name, peerUniquerPort))
+#@       env.append("CORE_PEER_LISTENADDRESS=0.0.0.0:{}".format(peerUniquerPort))
+#@       env.append("CORE_PEER_CHAINCODELISTENADDRESS=0.0.0.0:{}".format(7052))
+#@       env.append("CORE_CHAINCODE_EXECUTETIMEOUT=1500s")
+#@       env.append("CORE_PEER_ID=peer{}-{}".format(j, org.name))
+#@       env.append("CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/fabric/artifacts/msp/crypto-config/peerOrganizations/{}/peers/peer{}-{}.{}/msp".format(org.name, j, org.name, org.name))
+#@       env.append("CORE_PEER_LOCALMSPID={}".format(org.mspId))
+#@       env.append("CORE_PEER_ADDRESS=peer{}-{}:{}".format(j, org.name, peerUniquerPort))
+#@       env.append("CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:9443")
+#@       env.append("CORE_PEER_CHAINCODEADDRESS=peer{}-{}:{}".format(j, org.name, 7052))
+#@       env.append("CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer{}-{}:{}".format(j, org.name, peerUniquerPort))
+#@       env.append("CORE_OPERATIONS_TLS_ENABLED=false")
+#@       env.append("CORE_METRICS_PROVIDER=prometheus")
+#@       if config.tls == "mutual":
+#@         env.append("CORE_PEER_TLS_CLIENTROOTCAS_FILES={}".format(" ".join(mutualTLS(config))))
+#@         env.append("CORE_PEER_TLS_CLIENTAUTHREQUIRED=true")
+#@         env.append("CORE_PEER_TLS_ENABLED=true")
+#@       else:
+#@         env.append("CORE_PEER_TLS_ENABLED={}".format(config.tls))
+#@       end
+#@       env.append("CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/fabric/artifacts/msp/crypto-config/peerOrganizations/{}/peers/peer{}-{}.{}/tls/server.crt".format(org.name, j, org.name, org.name))
+#@       env.append("CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/fabric/artifacts/msp/crypto-config/peerOrganizations/{}/peers/peer{}-{}.{}/tls/server.key".format(org.name, j, org.name, org.name))
+#@       env.append("CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/fabric/artifacts/msp/crypto-config/peerOrganizations/{}/peers/peer{}-{}.{}/tls/ca.crt".format(org.name, j, org.name, org.name))
+#@       container_name = "peer{}-{}".format(j, org.name)
+#@       volumes = ["{}:/etc/hyperledger/fabric/artifacts/msp/".format(artifactsLocation)]
+#@       volumes.append("/var/run/:/host/var/run/")
+#@       volumes.append("{}/backup/peer{}-{}:/var/hyperledger/production".format(artifactsLocation,j, org.name))
+#@       image = ""
+#@       if validateAttributeExists(config, "peer"):
+#@         image = config.dockerImages.peer
+#@       else:
+#@         image = "{}/fabric-peer:{}".format(config.dockerOrg, config.dockerTag)
+#@       end
+#@       if validateAttributeExists(config, "ccenv"):
+#@         env.append("CORE_CHAINCODE_BUILDER={}".format(config.dockerImages.ccenv))
+#@       else:
+#@         env.append("CORE_CHAINCODE_BUILDER={}/fabric-ccenv:{}".format(config.dockerOrg, config.dockerTag))
+#@       end
+#@       if validateAttributeExists(config, "baseos"):
+#@         env.append("CORE_CHAINCODE_GOLANG_RUNTIME={}".format(config.dockerImages.baseos))
+#@       else:
+#@         env.append("CORE_CHAINCODE_GOLANG_RUNTIME={}/fabric-baseos:{}".format(config.dockerOrg, config.dockerTag))
+#@       end
+#@       if validateAttributeExists(config, "javaenv"):
+#@         env.append("CORE_CHAINCODE_JAVA_RUNTIME={}".format(config.dockerImages.javaenv))
+#@       else:
+#@         env.append("CORE_CHAINCODE_JAVA_RUNTIME={}/fabric-javaenv:{}".format(config.dockerOrg, config.dockerTag))
+#@       end
+#@       if validateAttributeExists(config, "nodeenv"):
+#@         env.append("CORE_CHAINCODE_NODE_RUNTIME={}".format(config.dockerImages.nodeenv))
+#@       else:
+#@         env.append("CORE_CHAINCODE_NODE_RUNTIME={}/fabric-nodeenv:{}".format(config.dockerOrg, config.dockerTag))
+#@       end
+#@       ports = ["7051", "{}:{}".format(peerUniquerPort,peerUniquerPort), "{}:{}".format(peerHealthCheckPort,9443)]
+#@       services[container_name] = {"image":image, "environment":env, "volumes":volumes, "ports":ports, "working_dir":"/opt/gopath/src/github.com/hyperledger/fabric/peer", "command":"peer node start", "container_name":container_name}
+#@       if config.dbType == "couchdb":
+#@         env.append("CORE_LEDGER_STATE_STATEDATABASE=CouchDB")
+#@         env.append("CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=couchdb-{}:5984".format(container_name))
+#@         services[container_name] = {"image":image, "environment":env, "volumes":volumes, "ports":ports, "working_dir":"/opt/gopath/src/github.com/hyperledger/fabric/peer", "command":"peer node start", "container_name":container_name, "depends_on":["couchdb-{}".format(container_name)]}
+#@       end
+#@       peerUniquerPort += 1
+#@       peerHealthCheckPort += 1
+#@     end
+#@     end
+#@     end
+#@   end
+#@ end
+
+#@ config = data.values
+#@ artifactsLocation = config.artifactsLocation
+#@ if artifactsLocation.endswith("/") == False:
+#@   artifactsLocation = artifactsLocation + "/"
+#@ end
+version: '2'
+#@ if config.dbType == "couchdb":
+#@   couchDB(config)
+#@ end
+#@ peers(config)
+networks:
+  default:
+    external:
+      name: configfiles_default
+services: #@ services

--- a/tools/operator/testclient/inputStructs/structs.go
+++ b/tools/operator/testclient/inputStructs/structs.go
@@ -2,17 +2,19 @@ package inputStructs
 
 //Config --
 type Config struct {
-	OrdererSystemChannel string           `yaml:"ordererSystemChannel,omitempty"`
-	Organizations        []Organization   `yaml:"organizations,omitempty"`
-	CreateChannel        []Channel        `yaml:"createChannel,omitempty"`
-	AnchorPeerUpdate     []Channel        `yaml:"anchorPeerUpdate,omitempty"`
-	JoinChannel          []Channel        `yaml:"joinChannel,omitempty"`
-	InstallCC            []InstallCC      `yaml:"installChaincode,omitempty"`
-	InstantiateCC        []InstantiateCC  `yaml:"instantiateChaincode,omitempty"`
-	UpgradeCC            []InstantiateCC  `yaml:"upgradeChaincode,omitempty"`
-	Invoke               []InvokeQuery    `yaml:"invokes,omitempty"`
-	Query                []InvokeQuery    `yaml:"queries,omitempty"`
-	CommandOptions       []CommandOptions `yaml:"command,omitempty"`
+	OrdererSystemChannel  string                  `yaml:"ordererSystemChannel,omitempty"`
+	Organizations         []Organization          `yaml:"organizations,omitempty"`
+	CreateChannel         []Channel               `yaml:"createChannel,omitempty"`
+	AnchorPeerUpdate      []Channel               `yaml:"anchorPeerUpdate,omitempty"`
+	JoinChannel           []Channel               `yaml:"joinChannel,omitempty"`
+	JoinChannelBySnapshot []JoinChannelBySnapshot `yaml:"joinChannelBySnapshot,omitempty"`
+	SnapshotChannel       []Snapshot              `yaml:"snapshotChannel,omitempty"`
+	InstallCC             []InstallCC             `yaml:"installChaincode,omitempty"`
+	InstantiateCC         []InstantiateCC         `yaml:"instantiateChaincode,omitempty"`
+	UpgradeCC             []InstantiateCC         `yaml:"upgradeChaincode,omitempty"`
+	Invoke                []InvokeQuery           `yaml:"invokes,omitempty"`
+	Query                 []InvokeQuery           `yaml:"queries,omitempty"`
+	CommandOptions        []CommandOptions        `yaml:"command,omitempty"`
 }
 
 //Channel --
@@ -23,12 +25,30 @@ type Channel struct {
 	ChannelPrefix    string `yaml:"channelPrefix,omitempty"`
 	AnchorPeerTxPath string `yaml:"anchorPeerUpdateTxPath,omitempty"`
 	NumChannels      int    `yaml:"numChannels,omitempty"`
+	TargetPeers      string `yaml:"targetPeers,omitempty"`
+	SnapshotPath     string `yaml:"snapshotPath,omitempty"`
 }
 
 //Organization --
 type Organization struct {
 	Name            string `yaml:"name,omitempty"`
 	ConnProfilePath string `yaml:"connProfilePath,omitempty"`
+}
+
+type Snapshot struct {
+	ChannelName   string `yaml:"channelName,omitempty"`
+	Organizations string `yaml:"organizations,omitempty"`
+	BlockNumber   []int  `yaml:"blockNumber,omitempty"`
+	TargetPeers   string `yaml:"targetPeers,omitempty"`
+}
+
+type JoinChannelBySnapshot struct {
+	ChannelName   string `yaml:"channelName,omitempty"`
+	Organizations string `yaml:"organizations,omitempty"`
+	TargetPeers   string `yaml:"targetPeers,omitempty"`
+	SnapshotPath  string `yaml:"snapshotPath,omitempty"`
+	ChannelPrefix string `yaml:"channelPrefix,omitempty"`
+	NumChannels   int    `yaml:"numChannels,omitempty"`
 }
 
 //InstallCC --
@@ -89,12 +109,20 @@ type InvokeQuery struct {
 	OrdererFailOver  bool                 `yaml:"ordererFailover,omitempty"`
 	PeerOpt          PeerOptions          `yaml:"peerOptions,omitempty"`
 	OrdererOpt       OrdererOptions       `yaml:"ordererOptions,omitempty"`
+	SnapshotOpt      SnapshotOptions      `yaml:"snapshotOptions,omitempty"`
 }
 
 //TransactionOptions --
 type TransactionOptions struct {
 	Mode    string  `yaml:"mode,omitempty"`
 	Options Options `yaml:"options,omitempty"`
+}
+
+type SnapshotOptions struct {
+	Enabled        bool   `yaml:"enabled,omitempty"`
+	Height         []int  `yaml:"height,omitempty"`
+	QueryFrequency int    `yaml:"queryFrequency,omitempty"`
+	SnapshotPeer   string `yaml:"snapshotPeer,omitempty"`
 }
 
 //Options  --

--- a/tools/operator/testclient/operations/joinBySnapshot.go
+++ b/tools/operator/testclient/operations/joinBySnapshot.go
@@ -1,0 +1,195 @@
+package operations
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/hyperledger/fabric-test/tools/operator/connectionprofile"
+	"github.com/hyperledger/fabric-test/tools/operator/logger"
+	"github.com/hyperledger/fabric-test/tools/operator/networkclient"
+	"github.com/hyperledger/fabric-test/tools/operator/paths"
+	"github.com/hyperledger/fabric-test/tools/operator/testclient/inputStructs"
+)
+
+//JoinBySnapshotUIObject --
+type JoinBySnapshotUIObject struct {
+	TLS             string         `json:"TLS,omitempty"`
+	ChannelOpt      ChannelOptions `json:"ChannelOpt,omitempty"`
+	ConnProfilePath string         `json:"ConnProfilePath,omitempty"`
+	TargetPeers     []string       `json:"targetPeers,omitempty"`
+	SnapshotPath    string
+	SnapshotPeer    string
+}
+
+//JoinBySnapshot -- To join channel using snapshot
+func (j JoinBySnapshotUIObject) JoinBySnapshot(config inputStructs.Config, tls string) error {
+
+	var joinBySnapshotObjects []JoinBySnapshotUIObject
+	var joinBySnapshotConfigObjects []interface{}
+	var configObjects []inputStructs.JoinChannelBySnapshot
+	configObjects = config.JoinChannelBySnapshot
+	for index := 0; index < len(configObjects); index++ {
+		ccObjects := j.createJoinBySnapshotObjects(configObjects[index], config.Organizations, tls)
+		joinBySnapshotObjects = append(joinBySnapshotObjects, ccObjects...)
+		joinBySnapshotConfigObjects = append(joinBySnapshotConfigObjects, &config.JoinChannelBySnapshot[index])
+	}
+	err := j.joinBySnapshot(joinBySnapshotObjects)
+	if err != nil {
+		return err
+	}
+	var connProfileObject connectionprofile.ConnProfile
+	err = connProfileObject.UpdateConnectionProfiles(joinBySnapshotConfigObjects, config.Organizations, "joinBySnapshot")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+//createSnapshotObjects -- To create snapshot objects for snapshot
+func (j JoinBySnapshotUIObject) createJoinBySnapshotObjects(ccObject inputStructs.JoinChannelBySnapshot, organizations []inputStructs.Organization, tls string) []JoinBySnapshotUIObject {
+
+	var joinBySnapshotObjects []JoinBySnapshotUIObject
+	orgNames := strings.Split(ccObject.Organizations, ",")
+	targetPeers := strings.Split(ccObject.TargetPeers, ",")
+	snapshotConfig := strings.Split(ccObject.SnapshotPath, ":")
+
+	j = JoinBySnapshotUIObject{
+		TLS: tls,
+		ChannelOpt: ChannelOptions{
+			OrgName: orgNames,
+			Name:    ccObject.ChannelName,
+		},
+		TargetPeers:     targetPeers,
+		SnapshotPeer:    snapshotConfig[0],
+		SnapshotPath:    snapshotConfig[1],
+		ConnProfilePath: paths.GetConnProfilePath(orgNames, organizations),
+	}
+	joinBySnapshotObjects = append(joinBySnapshotObjects, j)
+	return joinBySnapshotObjects
+}
+
+//joinBysnapshotCLI -- to join the channel using snapshot
+func (j JoinBySnapshotUIObject) joinBySnapshotCLI(joinBySnapshotObject JoinBySnapshotUIObject) error {
+
+	for _, orgName := range joinBySnapshotObject.ChannelOpt.OrgName {
+		currentDir, err := paths.GetCurrentDir()
+		if err != nil {
+			return err
+		}
+		var connProfilePath string
+		if strings.Contains(joinBySnapshotObject.ConnProfilePath, ".yaml") || strings.Contains(joinBySnapshotObject.ConnProfilePath, ".json") {
+			connProfilePath = joinBySnapshotObject.ConnProfilePath
+		} else {
+			connProfilePath = fmt.Sprintf("%s/connection_profile_%s.yaml", joinBySnapshotObject.ConnProfilePath, orgName)
+		}
+		for _, peerName := range joinBySnapshotObject.TargetPeers {
+			peerOrgName := strings.Split(peerName, "-")
+			if peerOrgName[1] == orgName {
+				connProfConfig, err := ConnProfileInformationForOrg(connProfilePath, orgName)
+				if err != nil {
+					return err
+				}
+				peerURL, err := url.Parse(connProfConfig.Peers[peerName].URL)
+				if err != nil {
+					logger.ERROR("Failed to get peer url from connection profile")
+					return err
+				}
+				peerAddress := peerURL.Host
+				err = SetEnvForCLI(orgName, peerName, connProfilePath, joinBySnapshotObject.TLS, currentDir)
+				if err != nil {
+					return err
+				}
+				args := []string{
+					"channel",
+					"joinbysnapshot",
+					"--snapshotpath",
+				}
+				os.Setenv("CORE_PEER_ADDRESS", peerAddress)
+				if os.Getenv("KUBECONFIG") != "" || strings.Contains(peerAddress, "127.0.0.1") {
+					err = j.copySnapshotDirectoryDocker(peerName, joinBySnapshotObject)
+					if err != nil {
+						return err
+					}
+					args = append(args, fmt.Sprintf("/var/hyperledger/production/ledgersData/snapshots/completed/%s", joinBySnapshotObject.SnapshotPath))
+				} else {
+					err = j.copySnapshotDirectoryK8s(peerName, joinBySnapshotObject)
+					if err != nil {
+						return err
+					}
+					args = append(args, fmt.Sprintf("/shared/data/ledgersData/snapshots/completed/%s", joinBySnapshotObject.SnapshotPath))
+				}
+				_, err = networkclient.ExecuteCommand("peer", args, true)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (j JoinBySnapshotUIObject) copySnapshotDirectoryDocker(peer string, joinBySnapshotObject JoinBySnapshotUIObject) error {
+
+	ctx := context.Background()
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return err
+	}
+	content, _, err := cli.CopyFromContainer(ctx, joinBySnapshotObject.SnapshotPeer, fmt.Sprintf("/var/hyperledger/production/ledgersData/snapshots/completed/%s/%s", joinBySnapshotObject.ChannelOpt.Name, joinBySnapshotObject.SnapshotPath))
+	if err != nil {
+		return err
+	}
+	options := types.CopyToContainerOptions{AllowOverwriteDirWithFile: true, CopyUIDGID: false}
+	err = cli.CopyToContainer(ctx, peer, "/var/hyperledger/production/ledgersData/snapshots/completed/", content, options)
+	if err != nil {
+		return err
+	}
+	defer content.Close()
+	return nil
+}
+
+//TODO: to replace kubectl call with api call
+func (j JoinBySnapshotUIObject) copySnapshotDirectoryK8s(peer string, joinBySnapshotObject JoinBySnapshotUIObject) error {
+
+	copyFromArgs := []string{
+		"-n", "fabric-system-test",
+		"cp",
+		fmt.Sprintf("%s-0:/shared/data/ledgersData/snapshots/completed/%s/%s", joinBySnapshotObject.SnapshotPeer, joinBySnapshotObject.ChannelOpt.Name, joinBySnapshotObject.SnapshotPath),
+		fmt.Sprintf("/tmp/%s", joinBySnapshotObject.SnapshotPath),
+		"-c", "peer",
+	}
+	_, err := networkclient.ExecuteCommand("kubectl", copyFromArgs, true)
+	if err != nil {
+		return err
+	}
+	copyToArgs := []string{
+		"-n", "fabric-system-test",
+		"cp",
+		fmt.Sprintf("/tmp/%s", joinBySnapshotObject.SnapshotPath),
+		fmt.Sprintf("%s-0:/shared/data/ledgersData/snapshots/completed/%s", peer, joinBySnapshotObject.SnapshotPath),
+		"-c", "peer",
+	}
+	_, err = networkclient.ExecuteCommand("kubectl", copyToArgs, true)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+//joinBySnapshot -- To join peer to channel using snapshot
+func (j JoinBySnapshotUIObject) joinBySnapshot(joinBySnapshotObjects []JoinBySnapshotUIObject) error {
+
+	var err error
+	for i := 0; i < len(joinBySnapshotObjects); i++ {
+		err = j.joinBySnapshotCLI(joinBySnapshotObjects[i])
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}

--- a/tools/operator/testclient/operations/snapshot.go
+++ b/tools/operator/testclient/operations/snapshot.go
@@ -1,0 +1,123 @@
+package operations
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/hyperledger/fabric-test/tools/operator/logger"
+	"github.com/hyperledger/fabric-test/tools/operator/networkclient"
+	"github.com/hyperledger/fabric-test/tools/operator/paths"
+	"github.com/hyperledger/fabric-test/tools/operator/testclient/inputStructs"
+)
+
+//SnapshotUIObject --
+type SnapshotUIObject struct {
+	SDK             string         `json:"sdk,omitempty"`
+	TLS             string         `json:"TLS,omitempty"`
+	BlockNumber     int            `json:"BlockNumber,omitempty"`
+	ChannelOpt      ChannelOptions `json:"ChannelOpt,omitempty"`
+	ConnProfilePath string         `json:"ConnProfilePath,omitempty"`
+	TargetPeers     []string       `json:"targetPeers,omitempty"`
+}
+
+//Snapshot -- To snapshot channel
+func (s SnapshotUIObject) Snapshot(config inputStructs.Config, tls string) error {
+
+	var snapshotObjects []SnapshotUIObject
+	for index := 0; index < len(config.SnapshotChannel); index++ {
+		ccObjects := s.createSnapshotObjects(config.SnapshotChannel[index], config.Organizations, tls)
+		snapshotObjects = append(snapshotObjects, ccObjects...)
+	}
+	err := s.snapshot(snapshotObjects)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+//createSnapshotObjects -- To create snapshot objects for snapshot
+func (s SnapshotUIObject) createSnapshotObjects(ccObject inputStructs.Snapshot, organizations []inputStructs.Organization, tls string) []SnapshotUIObject {
+
+	var snapshotObjects []SnapshotUIObject
+	orgNames := strings.Split(ccObject.Organizations, ",")
+	targetPeers := strings.Split(ccObject.TargetPeers, ",")
+	for _, blockNumber := range ccObject.BlockNumber {
+		s = SnapshotUIObject{
+			TLS:         tls,
+			BlockNumber: blockNumber,
+			ChannelOpt: ChannelOptions{
+				OrgName: orgNames,
+				Name:    ccObject.ChannelName,
+			},
+			TargetPeers:     targetPeers,
+			ConnProfilePath: paths.GetConnProfilePath(orgNames, organizations),
+		}
+		snapshotObjects = append(snapshotObjects, s)
+	}
+	return snapshotObjects
+}
+
+//snapshotCLI --
+func (s SnapshotUIObject) snapshotCLI(snapshotObject SnapshotUIObject) error {
+
+	for _, orgName := range snapshotObject.ChannelOpt.OrgName {
+		currentDir, err := paths.GetCurrentDir()
+		if err != nil {
+			return err
+		}
+		var connProfilePath string
+		if strings.Contains(snapshotObject.ConnProfilePath, ".yaml") || strings.Contains(snapshotObject.ConnProfilePath, ".json") {
+			connProfilePath = snapshotObject.ConnProfilePath
+		} else {
+			connProfilePath = fmt.Sprintf("%s/connection_profile_%s.yaml", snapshotObject.ConnProfilePath, orgName)
+		}
+		for _, peerName := range snapshotObject.TargetPeers {
+			peerOrgName := strings.Split(peerName, "-")
+			if peerOrgName[1] == orgName {
+				connProfConfig, err := ConnProfileInformationForOrg(connProfilePath, orgName)
+				if err != nil {
+					return err
+				}
+				peerURL, err := url.Parse(connProfConfig.Peers[peerName].URL)
+				if err != nil {
+					logger.ERROR("Failed to get peer url from connection profile")
+					return err
+				}
+				peerAddress := peerURL.Host
+				err = SetEnvForCLI(orgName, peerName, connProfilePath, snapshotObject.TLS, currentDir)
+				if err != nil {
+					return err
+				}
+				args := []string{
+					"snapshot",
+					"submitrequest",
+					"-C", snapshotObject.ChannelOpt.Name,
+					"-b", strconv.Itoa(snapshotObject.BlockNumber),
+					"--peerAddress", peerAddress,
+					"--tlsRootCertFile",
+					fmt.Sprintf("%s/crypto-config/peerOrganizations/%s/peers/%s.%s/tls/ca.crt", currentDir, orgName, peerName, orgName),
+				}
+				_, err = networkclient.ExecuteCommand("peer", args, true)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+//Snapshot -- To snapshot ledger
+func (s SnapshotUIObject) snapshot(snapshotObjects []SnapshotUIObject) error {
+
+	var err error
+	for j := 0; j < len(snapshotObjects); j++ {
+		err = s.snapshotCLI(snapshotObjects[j])
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}

--- a/tools/operator/testclient/testclient.go
+++ b/tools/operator/testclient/testclient.go
@@ -43,7 +43,7 @@ func doAction(action string, config inputStructs.Config, testInputFilePath strin
 	var err error
 	var connectionProfileFileContents []byte
 	tls := "disabled"
-	supportedActions := "create|anchorpeer|join|install|instantiate|upgrade|invoke|query|command"
+	supportedActions := "create|anchorpeer|join|joinBySnapshot|install|instantiate|upgrade|invoke|query|command|snapshot"
 	if strings.HasSuffix(config.Organizations[0].ConnProfilePath, "yaml") || strings.HasSuffix(config.Organizations[0].ConnProfilePath, "yml") {
 		connectionProfileFileContents, err = ioutil.ReadFile(config.Organizations[0].ConnProfilePath)
 	} else {
@@ -70,6 +70,18 @@ func doAction(action string, config inputStructs.Config, testInputFilePath strin
 		case "create", "join", "anchorpeer":
 			var channelUIObject operations.ChannelUIObject
 			err := channelUIObject.ChannelConfigs(config, tls, action)
+			if err != nil {
+				return err
+			}
+		case "joinBySnapshot":
+			var joinBySnapshotUIObject operations.JoinBySnapshotUIObject
+			err := joinBySnapshotUIObject.JoinBySnapshot(config, tls)
+			if err != nil {
+				return err
+			}
+		case "snapshot":
+			var snapshotUIObject operations.SnapshotUIObject
+			err := snapshotUIObject.Snapshot(config, tls)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Enhancing operator tool to support launching new peers to organizations, snapshot ledger on a peer and joining the peer to channel using snapshot, updating connection profiles

Usage:
To add new peers to existing network using network input file:
go run main.go -i ../../regression/testdata/basic-network-spec.yml -a up (for docker)
go run main.go -i ../../regression/testdata/basic-network-spec.yml -a up -k $KUBECONFIG (for k8s)

To snapshot the ledger at listed block number in test input yml under snapshotChannel section:
  go run main.go -i ../../regression/testdata/basic-test-input.yml  -a snapshot

To join listed peers using snapshot directory in test input yml under joinChannelBySnapshot section:
  go run main.go -i ../../regression/testdata/basic-test-input.yml  -a joinBySnapshot
To join peers running k8s, export KUBECONFIG=<path to kubeconfig file of the cluster>
