### PR TITLE
Fix chaincode-integration permission denied error

### DIFF
--- a/tools/chaincode-integration/src/utils/docker.ts
+++ b/tools/chaincode-integration/src/utils/docker.ts
@@ -65,7 +65,7 @@ export class Docker {
     }
 
     public static async exec(container: string, command: string): Promise<string> {
-        return await exec(`docker exec ${container} ${command}`);
+        return await exec(`docker exec -t ${container} ${command}`);
     }
 
     public static async removeContainers(partialName: string) {


### PR DESCRIPTION
Getting `unable to create context store: mkdir /etc/hyperledger: permission denied` errors which appears to go away with `docker exec -t` for some reason

Signed-off-by: James Taylor <jamest@uk.ibm.com>