### PR TITLE
Move docker images publishing higher in ci publish order

### DIFF
--- a/ci/azure-pipelines-interop.yml
+++ b/ci/azure-pipelines-interop.yml
@@ -259,6 +259,11 @@ stages:
           - template: templates/install_deps.yml
           - script: ./ci/scripts/interop/common/load-docker-images.sh
             displayName: Load Docker Images
+          - script: ./ci/scripts/interop/publish/docker-images.sh
+            env:
+              ARTIFACTORY_USERNAME: $(ARTIFACTORY_USERNAME)
+              ARTIFACTORY_PASSWORD: $(ARTIFACTORY_PASSWORD)
+            displayName: Publish Docker Images
           - script: ./ci/scripts/interop/publish/fabric-binary.sh
             env:
               ARTIFACTORY_USERNAME: $(ARTIFACTORY_USERNAME)
@@ -269,11 +274,6 @@ stages:
               ARTIFACTORY_USERNAME: $(ARTIFACTORY_USERNAME)
               ARTIFACTORY_PASSWORD: $(ARTIFACTORY_PASSWORD)
             displayName: Publish Fabric-CA Binaries
-          - script: ./ci/scripts/interop/publish/docker-images.sh
-            env:
-              ARTIFACTORY_USERNAME: $(ARTIFACTORY_USERNAME)
-              ARTIFACTORY_PASSWORD: $(ARTIFACTORY_PASSWORD)
-            displayName: Publish Docker Images
 
 # TODO: Implement testing for the Gateways and Contracts
 


### PR DESCRIPTION
Publish docker images first to prevent failure from binary compilation

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>