### PR TITLE
Fabric-Test-Daily to use latest images

### DIFF
--- a/regression/testdata/12hr80tps4org2chan-network-spec.yml
+++ b/regression/testdata/12hr80tps4org2chan-network-spec.yml
@@ -3,7 +3,7 @@
 #! SPDX-License-Identifier: Apache-2.0
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
-dockerTag: amd64-2.3-stable
+dockerTag: amd64-latest
 dockerImages:
   ca: hyperledger/fabric-ca:1.4
 

--- a/regression/testdata/barebones-network-spec.yml
+++ b/regression/testdata/barebones-network-spec.yml
@@ -4,7 +4,7 @@
 
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
-dockerTag: amd64-2.3-stable
+dockerTag: amd64-latest
 dockerImages:
   ca: hyperledger/fabric-ca:1.4
 

--- a/regression/testdata/basic-network-spec.yml
+++ b/regression/testdata/basic-network-spec.yml
@@ -4,7 +4,7 @@
 
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
-dockerTag: amd64-2.3-stable
+dockerTag: amd64-latest
 dockerImages:
   ca: hyperledger/fabric-ca:1.4
 

--- a/regression/testdata/k8s-run-network-spec.yml
+++ b/regression/testdata/k8s-run-network-spec.yml
@@ -3,7 +3,7 @@
 #! SPDX-License-Identifier: Apache-2.0
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
-dockerTag: amd64-2.3-stable
+dockerTag: amd64-latest
 dockerImages:
   ca: hyperledger/fabric-ca:1.4
 

--- a/regression/testdata/kafka-couchdb-tls-network-spec.yml
+++ b/regression/testdata/kafka-couchdb-tls-network-spec.yml
@@ -3,7 +3,7 @@
 #! SPDX-License-Identifier: Apache-2.0
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
-dockerTag: amd64-2.3-stable
+dockerTag: amd64-latest
 dockerImages:
   ca: hyperledger/fabric-ca:1.4
 

--- a/regression/testdata/kafka-leveldb-notls-network-spec.yml
+++ b/regression/testdata/kafka-leveldb-notls-network-spec.yml
@@ -3,7 +3,7 @@
 #! SPDX-License-Identifier: Apache-2.0
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
-dockerTag: amd64-2.3-stable
+dockerTag: amd64-latest
 dockerImages:
   ca: hyperledger/fabric-ca:1.4
 

--- a/regression/testdata/raft-couchdb-mutualtls-servdisc-network-spec.yml
+++ b/regression/testdata/raft-couchdb-mutualtls-servdisc-network-spec.yml
@@ -3,7 +3,7 @@
 #! SPDX-License-Identifier: Apache-2.0
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
-dockerTag: amd64-2.3-stable
+dockerTag: amd64-latest
 dockerImages:
   ca: hyperledger/fabric-ca:1.4
 


### PR DESCRIPTION
Fabric-Test-Daily tests on master were using the older 2.3-stable images
instead of the latest images published from fabric master.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>