### PR TITLE
Disable release tests for release-2.1 and release-2.0

### DIFF
--- a/ci/azure-pipelines-nightly.yml
+++ b/ci/azure-pipelines-nightly.yml
@@ -11,8 +11,6 @@ schedules:
     displayName: Daily midnight build
     branches:
       include:
-        - master
-        - release-2.*
         - release-1.4
     always: "true"
 


### PR DESCRIPTION
The nightly release tests have been replaced with interop tests in release-2.2 (current LTS release) and release-2.3.
The nightly release tests have been failing in release-2.1 since there is no associated branch in java chaincode.
This change will disable the failing tests that are no longer needed in release-2.1 and release-2.0.
The nightly release tests will continue running for release-1.4 (prior LTS release).

Signed-off-by: David Enyeart <enyeart@us.ibm.com>