### PR TITLE
release-2.3 should not publish as latest

### DIFF
--- a/ci/scripts/interop/publish/docker-images.sh
+++ b/ci/scripts/interop/publish/docker-images.sh
@@ -9,7 +9,4 @@ docker login -u "${ARTIFACTORY_USERNAME}" -p "${ARTIFACTORY_PASSWORD}" hyperledg
 for image in baseos peer orderer ccenv tools ca javaenv nodeenv; do
     docker tag "hyperledger/fabric-${image}" "hyperledger-fabric.jfrog.io/fabric-${image}:amd64-${RELEASE}"
     docker push "hyperledger-fabric.jfrog.io/fabric-${image}:amd64-${RELEASE}"
-
-    docker tag "hyperledger/fabric-${image}" "hyperledger-fabric.jfrog.io/fabric-${image}:amd64-latest"
-    docker push "hyperledger-fabric.jfrog.io/fabric-${image}:amd64-latest"
 done

--- a/ci/scripts/interop/publish/fabric-binary.sh
+++ b/ci/scripts/interop/publish/fabric-binary.sh
@@ -16,8 +16,5 @@ for target in linux-amd64 darwin-amd64; do
     curl -u"${ARTIFACTORY_USERNAME}":"${ARTIFACTORY_PASSWORD}" \
 		  -T "hyperledger-fabric-${target}-${RELEASE}.tar.gz" \
 		  "https://hyperledger.jfrog.io/hyperledger/fabric-binaries/hyperledger-fabric-${target}-${RELEASE}.tar.gz"
-		curl -u"${ARTIFACTORY_USERNAME}":"${ARTIFACTORY_PASSWORD}" \
-		  -T "hyperledger-fabric-${target}-${RELEASE}.tar.gz" \
-		  "https://hyperledger.jfrog.io/hyperledger/fabric-binaries/hyperledger-fabric-${target}-latest.tar.gz"
     popd
 done


### PR DESCRIPTION
release-2.3 docker images and binaries should not get published as 'latest'.
Only master branch should publish as 'latest', so that consumers of 'latest'
always test the latest from master.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>