### PR TITLE
Fix barebones caliper logging

### DIFF
--- a/regression/barebones_caliper/barebones_suite_test.go
+++ b/regression/barebones_caliper/barebones_suite_test.go
@@ -58,19 +58,13 @@ var _ = BeforeSuite(func() {
 
 	// set up input file variables
 	networkSpecPath = path.Join(testDataDir, "barebones-network-spec.yml")
-	inputSpecPath := path.Join(testDataDir, "barebones-test-input.yml")
-
-	// Use input "command" to print peer logs
-	action := "command"
-	err := testclient.Testclient(action, inputSpecPath)
-	Expect(err).NotTo(HaveOccurred())
 
 	// get kube config env
 	kubeConfig, containerType = getKubeConfig()
 
 	// bring up network
 	action = "up"
-	err = launcher.Launcher(action, containerType, kubeConfig, networkSpecPath)
+	err := launcher.Launcher(action, containerType, kubeConfig, networkSpecPath)
 	Expect(err).NotTo(HaveOccurred())
 })
 
@@ -81,12 +75,18 @@ var _ = AfterSuite(func() {
 
 	// set up input file variables
 	networkSpecPath = path.Join(testDataDir, "barebones-network-spec.yml")
+	inputSpecPath := path.Join(testDataDir, "barebones-test-input.yml")
+
+	// Use input "command" to print peer logs
+	action := "command"
+	err := testclient.Testclient(action, inputSpecPath)
+	Expect(err).NotTo(HaveOccurred())
 
 	// get kube config env
 	kubeConfig, containerType = getKubeConfig()
 
 	// bring down network
 	action = "down"
-	err := launcher.Launcher(action, containerType, kubeConfig, networkSpecPath)
+	err = launcher.Launcher(action, containerType, kubeConfig, networkSpecPath)
 	Expect(err).NotTo(HaveOccurred())
 })


### PR DESCRIPTION
When peer logging was added to the end of the tests,
for the barebones caliper test, it was accidentally
added to the BeforeSuite instead of AfterSuite.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>