### PR TITLE
Add Secondary CI Running On GitHub Actions

### DIFF
--- a/.github/workflows/daily-regression.yml
+++ b/.github/workflows/daily-regression.yml
@@ -1,0 +1,99 @@
+# Copyright the Hyperledger Fabric contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Daily Regression
+
+on:
+  workflow_dispatch:
+  schedule:
+    - "0 3 * * *"
+
+env:
+  GO_VER: 1.15.8
+  NODE_VER: 12.15.0
+  FABRIC_CFG_PATH: ${{ github.workspace }}/config
+  GOPATH: /tmp/go
+  PATH: /tmp/go/bin:/bin:${{ github.workspace }}/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
+
+jobs:
+  barebones:
+    name: Barbones Network
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ env.GO_VER }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VER }}
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Run Barebones Tests
+        run: make regression/barebones
+
+  barebones-caliper:
+    name: Barebones Caliper Network
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ env.GO_VER }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '10'
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Run Barebones Caliper Tests
+        run: make regression/barebones_caliper
+
+  basic:
+    name: Basic Network
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ env.GO_VER }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VER }}
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Run Basic Network Tests
+        run: make regression/basicnetwork
+
+  smoke:
+    name: Smoke Network
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ env.GO_VER }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VER }}
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Run Smoke Network Tests
+        run: make regression/smoke
+
+  hsm:
+    name: HSM Network
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ env.GO_VER }}
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Run HSM Tests
+        run: make regression/hsm

--- a/.github/workflows/daily-upgrade.yml
+++ b/.github/workflows/daily-upgrade.yml
@@ -1,0 +1,62 @@
+# Copyright the Hyperledger Fabric contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Daily Upgrade
+
+on:
+  workflow_dispatch:
+  schedule:
+    - "0 3 * * *"
+
+env:
+  GO_VER: 1.15.8
+  NODE_VER: 12.15.0
+  FABRIC_CFG_PATH: ${{ github.workspace }}/go/src/github.com/hyperledger/fabric-test/config
+  GOPATH: ${{ github.workspace }}/go
+  PATH: ${{ github.workspace }}/go/bin:/bin:${{ github.workspace }}/go/src/github.com/hyperledger/fabric-test/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
+
+defaults:
+  run:
+    working-directory: go/src/github.com/hyperledger/fabric-test
+
+jobs:
+  upgrade-2_2:
+    name: Upgrade Network
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ env.GO_VER }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VER }}
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: go/src/github.com/hyperledger/fabric-test
+      - name: Run Upgrade Tests
+        run: make upgrade2.2
+
+  upgrade-1_4-2_2:
+    name: Upgrade 1.4 Directly to 2.2 Network
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ env.GO_VER }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VER }}
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: go/src/github.com/hyperledger/fabric-test
+      - name: Run Upgrade Tests
+        run: make upgrade1.4to2.2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,70 @@
+# Copyright the Hyperledger Fabric contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Pull Request
+
+on:
+  pull_request:
+    paths-ignore:
+      - tools/chaincode-integration/*
+  push:
+    paths-ignore:
+      - tools/chaincode-integration/*
+
+env:
+  GO_VER: 1.15.8
+  NODE_VER: 12.15.0
+  FABRIC_CFG_PATH: ${{ github.workspace }}/config
+  GOPATH: /tmp/go
+  PATH: /tmp/go/bin:/bin:${{ github.workspace }}/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
+
+jobs:
+  verify:
+    name: Verify Build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ env.GO_VER }}
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Run Linter
+        run: make lint
+      - name: Run Unit Tests
+        run: make unit-tests
+
+  smoke:
+    name: Smoke Network
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ env.GO_VER }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VER }}
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Run Smoke Network Tests
+        run: make regression/smoke
+
+  basic:
+    name: Basic Network
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ env.GO_VER }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VER }}
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Run Basic Network Tests
+        run: make regression/basicnetwork

--- a/regression/upgrade/upgrade1.4to2.2.sh
+++ b/regression/upgrade/upgrade1.4to2.2.sh
@@ -3,8 +3,8 @@
 Tag14=1.4-stable
 Tag22=2.2-stable
 
-CurrentDirectory=$(cd `dirname $0` && pwd)
-FabricTestDir="$(echo $CurrentDirectory | awk -F'/fabric-test/' '{print $1}')/fabric-test"
+CurrentDirectory=$(cd "$(dirname $0)/../.." && pwd)
+FabricTestDir=$CurrentDirectory
 OperatorDir="$FabricTestDir"/tools/operator
 testdataDir="$FabricTestDir"/regression/testdata
 

--- a/regression/upgrade/upgrade2.2.sh
+++ b/regression/upgrade/upgrade2.2.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
-
+set -x
 Tag14=1.4-stable
 Tag20=2.0-stable
 Tag21=2.1-stable
 Tag22=2.2-stable
-
-CurrentDirectory=$(cd `dirname $0` && pwd)
-FabricTestDir="$(echo $CurrentDirectory | awk -F'/fabric-test/' '{print $1}')/fabric-test"
+CurrentDirectory=$(cd "$(dirname $0)/../.." && pwd)
+FabricTestDir=$CurrentDirectory
 OperatorDir="$FabricTestDir"/tools/operator
 testdataDir="$FabricTestDir"/regression/testdata
 


### PR DESCRIPTION
This is the first in a series of PR's migrating our Azure DevOp's CI to GitHub Actions.

The plan is to run non-publishing CI concurrently on GitHub Actions and Azure DevOp's, till we are comfortable with the GitHub Actions workflows.