### PR TITLE
Daily test should use fabric-ca:amd64-latest

### DIFF
--- a/regression/testdata/12hr80tps4org2chan-network-spec.yml
+++ b/regression/testdata/12hr80tps4org2chan-network-spec.yml
@@ -4,8 +4,10 @@
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
 dockerTag: amd64-latest
-dockerImages:
-  ca: hyperledger/fabric-ca:1.4
+#! dockerImages can provide an override for each of the seven fabric images
+#! for example, the following would override the fabric-ca image to use 1.4
+#! dockerImages:
+#!   ca: hyperledger/fabric-ca:1.4
 
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb

--- a/regression/testdata/barebones-network-spec.yml
+++ b/regression/testdata/barebones-network-spec.yml
@@ -5,8 +5,10 @@
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
 dockerTag: amd64-latest
-dockerImages:
-  ca: hyperledger/fabric-ca:1.4
+#! dockerImages can provide an override for each of the seven fabric images
+#! for example, the following would override the fabric-ca image to use 1.4
+#! dockerImages:
+#!   ca: hyperledger/fabric-ca:1.4
 
 #! peer database ledger type (couchdb, goleveldb)
 dbType: goleveldb

--- a/regression/testdata/basic-network-spec.yml
+++ b/regression/testdata/basic-network-spec.yml
@@ -5,8 +5,10 @@
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
 dockerTag: amd64-latest
-dockerImages:
-  ca: hyperledger/fabric-ca:1.4
+#! dockerImages can provide an override for each of the seven fabric images
+#! for example, the following would override the fabric-ca image to use 1.4
+#! dockerImages:
+#!   ca: hyperledger/fabric-ca:1.4
 
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb

--- a/regression/testdata/k8s-run-network-spec.yml
+++ b/regression/testdata/k8s-run-network-spec.yml
@@ -4,8 +4,10 @@
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
 dockerTag: amd64-latest
-dockerImages:
-  ca: hyperledger/fabric-ca:1.4
+#! dockerImages can provide an override for each of the seven fabric images
+#! for example, the following would override the fabric-ca image to use 1.4
+#! dockerImages:
+#!   ca: hyperledger/fabric-ca:1.4
 
 dbType: couchdb
 peerFabricLoggingSpec: info

--- a/regression/testdata/kafka-couchdb-tls-network-spec.yml
+++ b/regression/testdata/kafka-couchdb-tls-network-spec.yml
@@ -4,8 +4,10 @@
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
 dockerTag: amd64-latest
-dockerImages:
-  ca: hyperledger/fabric-ca:1.4
+#! dockerImages can provide an override for each of the seven fabric images
+#! for example, the following would override the fabric-ca image to use 1.4
+#! dockerImages:
+#!   ca: hyperledger/fabric-ca:1.4
 
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb

--- a/regression/testdata/kafka-leveldb-notls-network-spec.yml
+++ b/regression/testdata/kafka-leveldb-notls-network-spec.yml
@@ -4,8 +4,10 @@
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
 dockerTag: amd64-latest
-dockerImages:
-  ca: hyperledger/fabric-ca:1.4
+#! dockerImages can provide an override for each of the seven fabric images
+#! for example, the following would override the fabric-ca image to use 1.4
+#! dockerImages:
+#!   ca: hyperledger/fabric-ca:1.4
 
 #! peer database ledger type (couchdb, goleveldb)
 dbType: goleveldb

--- a/regression/testdata/raft-couchdb-mutualtls-servdisc-network-spec.yml
+++ b/regression/testdata/raft-couchdb-mutualtls-servdisc-network-spec.yml
@@ -4,8 +4,10 @@
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
 dockerTag: amd64-latest
-dockerImages:
-  ca: hyperledger/fabric-ca:1.4
+#! dockerImages can provide an override for each of the seven fabric images
+#! for example, the following would override the fabric-ca image to use 1.4
+#! dockerImages:
+#!   ca: hyperledger/fabric-ca:1.4
 
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb

--- a/regression/testdata/smoke-network-spec.yml
+++ b/regression/testdata/smoke-network-spec.yml
@@ -4,8 +4,10 @@
 ---
 dockerOrg: hyperledger-fabric.jfrog.io
 dockerTag: amd64-latest
-dockerImages:
-  ca: hyperledger/fabric-ca:1.4
+#! dockerImages can provide an override for each of the seven fabric images
+#! for example, the following would override the fabric-ca image to use 1.4
+#! dockerImages:
+#!   ca: hyperledger/fabric-ca:1.4
 
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb


### PR DESCRIPTION
Daily tests were using fabric-ca:1.4 images from dockerhub.
Since we will release fabric-ca v1.5 from master branch,
tests in master branch should test with the published fabric-ca:amd64-latest images.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>