### PR TITLE
Schedule Interop for midnight UTC (release-2.2)

### DIFF
--- a/ci/azure-pipelines-interop.yml
+++ b/ci/azure-pipelines-interop.yml
@@ -6,8 +6,8 @@ name: InterOpLite-$(Date:yyyyMMdd)
 trigger: none
 pr: none
 schedules:
-  # 3 AM UTC
-  - cron: "0 3 * * *"
+  # Midnight UTC
+  - cron: "0 0 * * *"
     displayName: InterOp Testing
     branches:
       include:


### PR DESCRIPTION
Interop pipeline publishes images that are used in
Daily system tests. Therfore Interop pipeline
should run prior to Daily pipeline.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>