### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Fabric Test Maintainers
-*	@lindluni @denyeart @dongmingh @mastersingh24 @scottz64 @suryalnvs
-/tools/chaincode-integration @awjh-ibm @mbwhite
+*	@fabric-test-maintainers
+/tools/chaincode-integration    @fabric-test-toolchain-maintainers


### PR DESCRIPTION
Update CODEOWNERS to use org teams.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>