### PR TITLE
Add operator logging (release-2.3)

### DIFF
--- a/regression/barebones/barebones_suite_test.go
+++ b/regression/barebones/barebones_suite_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/hyperledger/fabric-test/tools/operator/launcher"
+	"github.com/hyperledger/fabric-test/tools/operator/testclient"
 )
 
 func TestPTEBarebones(t *testing.T) {
@@ -74,12 +75,18 @@ var _ = AfterSuite(func() {
 
 	// set up input file variables
 	networkSpecPath = path.Join(testDataDir, "barebones-network-spec.yml")
+	inputSpecPath := path.Join(testDataDir, "barebones-test-input.yml")
+
+	// Use input "command" to print peer logs
+	action := "command"
+	err := testclient.Testclient(action, inputSpecPath)
+	Expect(err).NotTo(HaveOccurred())
 
 	// get kube config env
 	kubeConfig, containerType = getKubeConfig()
 
 	// bring down network
 	action = "down"
-	err := launcher.Launcher(action, containerType, kubeConfig, networkSpecPath)
+	err = launcher.Launcher(action, containerType, kubeConfig, networkSpecPath)
 	Expect(err).NotTo(HaveOccurred())
 })

--- a/regression/barebones/barebones_test.go
+++ b/regression/barebones/barebones_test.go
@@ -12,7 +12,7 @@ import (
 var _ = Describe("Barebones Test", func() {
 
 	var (
-		inputSpecPath       string
+		inputSpecPath string
 	)
 
 	It("Running barebones Test)", func() {
@@ -51,6 +51,5 @@ var _ = Describe("Barebones Test", func() {
 		action = "query"
 		err = testclient.Testclient(action, inputSpecPath)
 		Expect(err).NotTo(HaveOccurred())
-
 	})
 })

--- a/regression/barebones_caliper/barebones_suite_test.go
+++ b/regression/barebones_caliper/barebones_suite_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/hyperledger/fabric-test/tools/operator/launcher"
+	"github.com/hyperledger/fabric-test/tools/operator/testclient"
 )
 
 func TestCaliperBarebones(t *testing.T) {
@@ -74,12 +75,18 @@ var _ = AfterSuite(func() {
 
 	// set up input file variables
 	networkSpecPath = path.Join(testDataDir, "barebones-network-spec.yml")
+	inputSpecPath := path.Join(testDataDir, "barebones-test-input.yml")
+
+	// Use input "command" to print peer logs
+	action := "command"
+	err := testclient.Testclient(action, inputSpecPath)
+	Expect(err).NotTo(HaveOccurred())
 
 	// get kube config env
 	kubeConfig, containerType = getKubeConfig()
 
 	// bring down network
 	action = "down"
-	err := launcher.Launcher(action, containerType, kubeConfig, networkSpecPath)
+	err = launcher.Launcher(action, containerType, kubeConfig, networkSpecPath)
 	Expect(err).NotTo(HaveOccurred())
 })

--- a/regression/barebones_caliper/barebones_test.go
+++ b/regression/barebones_caliper/barebones_test.go
@@ -57,6 +57,5 @@ var _ = Describe("Barebones Caliper Test", func() {
 			"--caliper-flow-only-test",
 		}
 		networkclient.ExecuteCommand("npx", caliperArgs, true)
-
 	})
 })

--- a/regression/basicnetwork/basicnetwork_suite_test.go
+++ b/regression/basicnetwork/basicnetwork_suite_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hyperledger/fabric-test/tools/operator/launcher"
 	"github.com/hyperledger/fabric-test/tools/operator/networkclient"
+	"github.com/hyperledger/fabric-test/tools/operator/testclient"
 )
 
 func TestBasicnetwork(t *testing.T) {
@@ -28,8 +29,15 @@ var _ = BeforeSuite(func() {
 // Cleaning up network launched from BeforeSuite and removing all chaincode containers
 // and chaincode container images using AfterSuite
 var _ = AfterSuite(func() {
+
+	// Use input "command" to print peer logs
+	inputSpecPath := "../testdata/basic-test-input.yml"
+	action := "command"
+	err := testclient.Testclient(action, inputSpecPath)
+	Expect(err).NotTo(HaveOccurred())
+
 	networkSpecPath := "../testdata/basic-network-spec.yml"
-	err := launcher.Launcher("down", "docker", "", networkSpecPath)
+	err = launcher.Launcher("down", "docker", "", networkSpecPath)
 	Expect(err).NotTo(HaveOccurred())
 
 	dockerList := []string{"ps", "-aq", "-f", "status=exited"}

--- a/regression/publish/publish_suite_test.go
+++ b/regression/publish/publish_suite_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/hyperledger/fabric-test/tools/operator/launcher"
+	"github.com/hyperledger/fabric-test/tools/operator/testclient"
 )
 
 func TestSmoke(t *testing.T) {
@@ -29,8 +30,15 @@ var _ = BeforeSuite(func() {
 //Cleaning up network launched from BeforeSuite and removing all chaincode containers
 //and chaincode container images using AfterSuite
 var _ = AfterSuite(func() {
+
+	// Use input "command" to print peer logs
+	inputSpecPath := "../testdata/publish-test-input.yml"
+	action := "command"
+	err := testclient.Testclient(action, inputSpecPath)
+	Expect(err).NotTo(HaveOccurred())
+
 	networkSpecPath := "../testdata/publish-network-spec.yml"
-	err := launcher.Launcher("down", "docker", "", networkSpecPath)
+	err = launcher.Launcher("down", "docker", "", networkSpecPath)
 	Expect(err).NotTo(HaveOccurred())
 
 	dockerList := []string{"ps", "-aq", "-f", "status=exited"}

--- a/regression/smoke/smoke_suite_test.go
+++ b/regression/smoke/smoke_suite_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hyperledger/fabric-test/tools/operator/launcher"
 	"github.com/hyperledger/fabric-test/tools/operator/networkclient"
+	"github.com/hyperledger/fabric-test/tools/operator/testclient"
 )
 
 func TestSmoke(t *testing.T) {
@@ -20,6 +21,7 @@ func TestSmoke(t *testing.T) {
 
 // Bringing up network using BeforeSuite
 var _ = BeforeSuite(func() {
+
 	networkSpecPath := "../testdata/smoke-network-spec.yml"
 	err := launcher.Launcher("up", "docker", "", networkSpecPath)
 	Expect(err).NotTo(HaveOccurred())
@@ -28,8 +30,15 @@ var _ = BeforeSuite(func() {
 // Cleaning up network launched from BeforeSuite and removing all chaincode containers
 // and chaincode container images using AfterSuite
 var _ = AfterSuite(func() {
+
+	// Use input "command" to print peer logs
+	inputSpecPath := "../testdata/smoke-test-input.yml"
+	action := "command"
+	err := testclient.Testclient(action, inputSpecPath)
+	Expect(err).NotTo(HaveOccurred())
+
 	networkSpecPath := "../testdata/smoke-network-spec.yml"
-	err := launcher.Launcher("down", "docker", "", networkSpecPath)
+	err = launcher.Launcher("down", "docker", "", networkSpecPath)
 	Expect(err).NotTo(HaveOccurred())
 
 	dockerList := []string{"ps", "-aq", "-f", "status=exited"}

--- a/regression/smoke/smoke_test.go
+++ b/regression/smoke/smoke_test.go
@@ -4,16 +4,16 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/hyperledger/fabric-test/tools/operator/testclient"
 	l "github.com/hyperledger/fabric-test/tools/operator/launcher"
+	"github.com/hyperledger/fabric-test/tools/operator/testclient"
 )
 
 var _ = Describe("Smoke Test Suite", func() {
 
 	Describe("Running Smoke Test Suite in fabric-test", func() {
 		var (
-			action        string
-			inputSpecPath string
+			action          string
+			inputSpecPath   string
 			networkSpecPath string
 		)
 		It("Running end to end (old cc lifecycle)", func() {
@@ -45,57 +45,42 @@ var _ = Describe("Smoke Test Suite", func() {
 			err = testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("6) Printing Peer Logs")
-			action = "command"
-			err = testclient.Testclient(action, inputSpecPath)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("7) Sending Queries")
+			By("6) Sending Queries")
 			action = "query"
 			err = testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("8) Snashot the ledger")
+			By("7) Snapshot the ledger")
 			action = "snapshot"
 			err = testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("9) Sending Invokes")
+			By("8) Sending Invokes")
 			action = "invoke"
 			err = testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("10) Printing Peer Logs")
-			action = "command"
-			err = testclient.Testclient(action, inputSpecPath)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("11) Adding new peer to the network")
+			By("9) Adding new peer to the network")
 			action = "addPeer"
 			err = l.Launcher(action, "docker", "", networkSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("12) Upgrading Chaincode")
+			By("10) Upgrading Chaincode")
 			action = "upgrade"
 			err = testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("13) Sending Queries")
+			By("11) Sending Queries")
 			action = "query"
 			testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("14) Printing Peer Logs")
-			action = "command"
-			err = testclient.Testclient(action, inputSpecPath)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("15) Join new peers using snapshot")
+			By("12) Join new peers using snapshot")
 			action = "joinBySnapshot"
 			err = testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("16) Sending Invokes")
+			By("13) Sending Invokes")
 			action = "invoke"
 			err = testclient.Testclient(action, inputSpecPath)
 			Expect(err).NotTo(HaveOccurred())

--- a/regression/testdata/barebones-network-spec.yml
+++ b/regression/testdata/barebones-network-spec.yml
@@ -11,9 +11,9 @@ dockerImages:
 #! peer database ledger type (couchdb, goleveldb)
 dbType: goleveldb
 #! This parameter is used to define fabric logging spec in peers
-peerFabricLoggingSpec: error
+peerFabricLoggingSpec: warn
 #! This parameter is used to define fabric logging spec in orderers
-ordererFabricLoggingSpec: error
+ordererFabricLoggingSpec: warn
 #! tls in the network (true, false or mutual(mutualtls))
 tls: true
 #! fabric metrics with prometheus (true/false)

--- a/regression/testdata/barebones-test-input.yml
+++ b/regression/testdata/barebones-test-input.yml
@@ -82,3 +82,9 @@ queries:
           constFreq: 0
           devFreq: 0
     args: "get,a1"
+
+command:
+  - name: docker
+    args:
+      - logs
+      - peer0-org1

--- a/regression/testdata/basic-test-input.yml
+++ b/regression/testdata/basic-test-input.yml
@@ -20,7 +20,7 @@ snapshotChannel:
   - channelName: testorgschannel0
     organizations: org1
     targetPeers: peer0-org1
-    blockNumber: 
+    blockNumber:
     - 1
 
 joinChannelBySnapshot:
@@ -97,7 +97,7 @@ invokes:
       payLoadMin: 1024
       payLoadMax: 2048
     args: "put,a1,1"
-  
+
   - channelName: testorgschannel0
     name: mapcc
     targetPeers: OrgAnchor
@@ -159,3 +159,9 @@ queries:
           constFreq: 0
           devFreq: 0
     args: "getPrivate,a1"
+
+command:
+  - name: docker
+    args:
+      - logs
+      - peer0-org1

--- a/regression/testdata/k8s-run-network-spec.yml
+++ b/regression/testdata/k8s-run-network-spec.yml
@@ -8,8 +8,8 @@ dockerImages:
   ca: hyperledger/fabric-ca:1.4
 
 dbType: couchdb
-peerFabricLoggingSpec: error
-ordererFabricLoggingSpec: error
+peerFabricLoggingSpec: info
+ordererFabricLoggingSpec: info
 tls: true
 metrics: true
 gossipEnable: false

--- a/regression/testdata/publish-network-spec.yml
+++ b/regression/testdata/publish-network-spec.yml
@@ -9,9 +9,9 @@ dockerTag: latest
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb
 #! This parameter is used to define fabric logging spec in peers
-peerFabricLoggingSpec: debug
+peerFabricLoggingSpec: info
 #! This parameter is used to define fabric logging spec in orderers
-ordererFabricLoggingSpec: debug
+ordererFabricLoggingSpec: info
 #! tls in the network (true, false or mutual(mutualtls))
 tls: true
 #! fabric metrics with prometheus (true/false)

--- a/regression/testdata/publish-test-input.yml
+++ b/regression/testdata/publish-test-input.yml
@@ -279,3 +279,9 @@ queries:
           constFreq: 0
           devFreq: 0
     args: "get,a1"
+
+command:
+  - name: docker
+    args:
+      - logs
+      - peer0-org1

--- a/regression/testdata/smoke-network-spec.yml
+++ b/regression/testdata/smoke-network-spec.yml
@@ -10,9 +10,9 @@ dockerImages:
 #! peer database ledger type (couchdb, goleveldb)
 dbType: couchdb
 #! This parameter is used to define fabric logging spec in peers
-peerFabricLoggingSpec: error
+peerFabricLoggingSpec: info
 #! This parameter is used to define fabric logging spec in orderers
-ordererFabricLoggingSpec: error
+ordererFabricLoggingSpec: info
 #! tls in the network (true, false or mutual(mutualtls))
 tls: true
 #! fabric metrics with prometheus (true/false)

--- a/regression/testdata/smoke-test-input.yml
+++ b/regression/testdata/smoke-test-input.yml
@@ -28,11 +28,11 @@ joinChannel:
     organizations: org1,org2
 
 snapshotChannel:
-# snapshot channel for the channel at the given block number 
+# snapshot channel for the channel at the given block number
   - channelName: testorgschannel0
     organizations: org1
     targetPeers: peer0-org1
-    blockNumber: 
+    blockNumber:
     - 10
     - 20
     - 30
@@ -141,16 +141,6 @@ queries:
     args: "get,a1"
 
 command:
-  - name: curl
-    args:
-      - -H 
-      - 'Content-Type: application/json'
-      - -X
-      - PUT
-      - -d
-      - '{"spec":"info"}'
-      - http://127.0.0.1:31100/logspec
-    
   - name: docker
     args:
       - logs

--- a/tools/operator/go.mod
+++ b/tools/operator/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/Shopify/sarama v1.26.4 // indirect
+	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/docker v17.12.0-ce-rc1.0.20190628135806-70f67c6240bb+incompatible
 	github.com/fsouza/go-dockerclient v1.6.3
 	github.com/golang/protobuf v1.3.3

--- a/tools/operator/launcher/launcher.go
+++ b/tools/operator/launcher/launcher.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hyperledger/fabric-test/tools/operator/launcher/dockercompose"
 	"github.com/hyperledger/fabric-test/tools/operator/launcher/k8s"
 	"github.com/hyperledger/fabric-test/tools/operator/launcher/nl"
@@ -33,6 +34,9 @@ func validateArguments(networkSpecPath string, kubeConfigPath string) error {
 }
 
 func doAction(action, env, kubeConfigPath string, config networkspec.Config) error {
+
+	// print action (in bold) and input
+	fmt.Printf("\033[1m\nAction:%s\nInput:\033[0m\n%s\n", action, spew.Sdump(config))
 
 	var err error
 	switch env {

--- a/tools/operator/networkclient/command.go
+++ b/tools/operator/networkclient/command.go
@@ -2,6 +2,7 @@ package networkclient
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -12,6 +13,9 @@ import (
 
 //ExecuteCommand - to execute the cli commands
 func ExecuteCommand(name string, args []string, printLogs bool) (string, error) {
+
+	// Print executed commands (in bold)
+	fmt.Println("\033[1m", ">", name, strings.Join(args, " "), "\033[0m")
 
 	cmd := exec.Command(name, args...)
 	var stdBuffer bytes.Buffer

--- a/tools/operator/testclient/operations/channelConfig.go
+++ b/tools/operator/testclient/operations/channelConfig.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hyperledger/fabric-test/tools/operator/connectionprofile"
 	"github.com/hyperledger/fabric-test/tools/operator/logger"
 	"github.com/hyperledger/fabric-test/tools/operator/networkclient"
@@ -48,6 +49,10 @@ func (c ChannelUIObject) ChannelConfigs(config inputStructs.Config, tls, action 
 	case "anchorpeer":
 		configObjects = config.AnchorPeerUpdate
 	}
+
+	// print action (in bold) and input
+	fmt.Printf("\033[1m\nAction:%s\nInput:\033[0m\n%s\n", action, spew.Sdump(configObjects))
+
 	for i := 0; i < len(configObjects); i++ {
 		channelObjects = c.generateChannelUIObjects(configObjects[i], config.Organizations, tls, action, config.OrdererSystemChannel)
 		if len(channelObjects) > 0 {

--- a/tools/operator/testclient/operations/installchaincode.go
+++ b/tools/operator/testclient/operations/installchaincode.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hyperledger/fabric-test/tools/operator/logger"
 	"github.com/hyperledger/fabric-test/tools/operator/networkclient"
 	"github.com/hyperledger/fabric-test/tools/operator/paths"
@@ -38,6 +39,9 @@ type InstallCCDeployOpt struct {
 
 //InstallCC -- To install chaincode with the chaincode objects created
 func (i InstallCCUIObject) InstallCC(config inputStructs.Config, tls string) error {
+
+	// print action (in bold) and input
+	fmt.Printf("\033[1m\nAction:install\nInput:\033[0m\n%s\n", spew.Sdump(config.InstallCC))
 
 	var installCCObjects []InstallCCUIObject
 	for index := 0; index < len(config.InstallCC); index++ {

--- a/tools/operator/testclient/operations/instantiatechaincode.go
+++ b/tools/operator/testclient/operations/instantiatechaincode.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hyperledger/fabric-test/tools/operator/connectionprofile"
 	"github.com/hyperledger/fabric-test/tools/operator/logger"
 	"github.com/hyperledger/fabric-test/tools/operator/networkclient"
@@ -103,6 +104,10 @@ func (i InstantiateCCUIObject) InstantiateCC(config inputStructs.Config, tls, ac
 	if action == "upgrade" {
 		configObjects = config.UpgradeCC
 	}
+
+	// print action (in bold) and input
+	fmt.Printf("\033[1m\nAction:%s\nInput:\033[0m\n%s\n", action, spew.Sdump(configObjects))
+
 	for index := 0; index < len(configObjects); index++ {
 		ccObjects, err := i.generateInstantiateCCObjects(configObjects[index], config.Organizations, tls, action)
 		if err != nil {

--- a/tools/operator/testclient/operations/invokequery.go
+++ b/tools/operator/testclient/operations/invokequery.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hyperledger/fabric-test/tools/operator/logger"
 	"github.com/hyperledger/fabric-test/tools/operator/networkclient"
 	"github.com/hyperledger/fabric-test/tools/operator/paths"
@@ -138,6 +139,10 @@ func (i InvokeQueryUIObject) InvokeQuery(config inputStructs.Config, tls, action
 	if action == "Query" {
 		configObjects = config.Query
 	}
+
+	// print action (in bold) and input
+	fmt.Printf("\033[1m\nAction:%s\nInput:\033[0m\n%s\n", action, spew.Sdump(configObjects))
+
 	for key := range configObjects {
 		invkQueryObjects := i.generateInvokeQueryObjects(configObjects[key], config.Organizations, tls, action)
 		invokeQueryObjects = append(invokeQueryObjects, invkQueryObjects...)

--- a/tools/operator/testclient/operations/joinBySnapshot.go
+++ b/tools/operator/testclient/operations/joinBySnapshot.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/hyperledger/fabric-test/tools/operator/connectionprofile"
@@ -33,6 +34,10 @@ func (j JoinBySnapshotUIObject) JoinBySnapshot(config inputStructs.Config, tls s
 	var joinBySnapshotConfigObjects []interface{}
 	var configObjects []inputStructs.JoinChannelBySnapshot
 	configObjects = config.JoinChannelBySnapshot
+
+	// print action (in bold) and input
+	fmt.Printf("\033[1m\nAction:joinBySnapshot\nInput:\033[0m\n%s\n", spew.Sdump(configObjects))
+
 	for index := 0; index < len(configObjects); index++ {
 		ccObjects := j.createJoinBySnapshotObjects(configObjects[index], config.Organizations, tls)
 		joinBySnapshotObjects = append(joinBySnapshotObjects, ccObjects...)

--- a/tools/operator/testclient/operations/snapshot.go
+++ b/tools/operator/testclient/operations/snapshot.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hyperledger/fabric-test/tools/operator/logger"
 	"github.com/hyperledger/fabric-test/tools/operator/networkclient"
 	"github.com/hyperledger/fabric-test/tools/operator/paths"
@@ -24,6 +25,9 @@ type SnapshotUIObject struct {
 
 //Snapshot -- To snapshot channel
 func (s SnapshotUIObject) Snapshot(config inputStructs.Config, tls string) error {
+
+	// print action (in bold) and input
+	fmt.Printf("\033[1m\nAction:snapshot\nInput:\033[0m\n%s\n", spew.Sdump(config.SnapshotChannel))
 
 	var snapshotObjects []SnapshotUIObject
 	for index := 0; index < len(config.SnapshotChannel); index++ {


### PR DESCRIPTION
Log operator actions and executed commands.
Previously, only the results of operator were logged.
Now we can also see what operator is doing as well.

Also, print peer logs after every test in the AfterSuite,
so that the logs print regardless of whether the test passes or fails.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>