### PR TITLE
Tag javaenv:amd64-latest to fix java chaincode integration tests

### DIFF
--- a/ci/scripts/interop/driver/fabric-chaincode-java.sh
+++ b/ci/scripts/interop/driver/fabric-chaincode-java.sh
@@ -7,4 +7,7 @@ set -euo pipefail
 cd "${ARTIFACT_DIRECTORY}/javaenv-source"
 tar -xf javaenv-source.tgz
 
+# java chaincode integration tests look for hyperledger/fabric-javaenv:amd64-latest in release-2.2
+docker tag hyperledger/fabric-javaenv:latest hyperledger/fabric-javaenv:amd64-latest
+
 ./gradlew build -x getLatestDockerImages -x buildImage


### PR DESCRIPTION
In release-2.2, java chaincode integration tests look for javaenv:amd64-latest
while only javaenv:latest image is available in the interop test environment.

Was receiving error:
"docker build failed: Failed to pull hyperledger/fabric-javaenv:amd64-latest".

Since this is a back release, just workaround the issue by tagging javaenv:amd64-latest
before the java chaincode integration tests run.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>