### PR TITLE
Interop test in release-2.3 should use release-2.2 SDKs

### DIFF
--- a/ci/scripts/interop/driver/fabric-sdk-java.sh
+++ b/ci/scripts/interop/driver/fabric-sdk-java.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
-git clone -b "${BRANCH}" https://github.com/hyperledger/fabric-sdk-java --single-branch "${ARTIFACT_DIRECTORY}/fabric-sdk-java"
+git clone -b release-2.2 https://github.com/hyperledger/fabric-sdk-java --single-branch "${ARTIFACT_DIRECTORY}/fabric-sdk-java"
 cd "${ARTIFACT_DIRECTORY}/fabric-sdk-java"
 
 sed -i '/source/d' ./scripts/run-integration-tests.sh

--- a/ci/scripts/interop/driver/fabric-sdk-node.sh
+++ b/ci/scripts/interop/driver/fabric-sdk-node.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
-git clone -b "${BRANCH}" https://github.com/hyperledger/fabric-sdk-node --single-branch "${ARTIFACT_DIRECTORY}/fabric-sdk-node"
+git clone -b release-2.2 https://github.com/hyperledger/fabric-sdk-node --single-branch "${ARTIFACT_DIRECTORY}/fabric-sdk-node"
 cd "${ARTIFACT_DIRECTORY}/fabric-sdk-node"
 
 npm install


### PR DESCRIPTION
There is no release-2.3 branch for SDKs.
release-2.3 Interop tests should use release-2.2 SDKs.
The change was already made for chaincodes, but not SDKs.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>