### PR TITLE
Update Java SDK interop test

### DIFF
--- a/ci/azure-pipelines-interop.yml
+++ b/ci/azure-pipelines-interop.yml
@@ -205,7 +205,7 @@ stages:
 
       - job: TestJavaSDK
         pool:
-          vmImage: ubuntu-18.04
+          vmImage: ubuntu-20.04
         steps:
           - download: current
             patterns: '*-docker.tgz'


### PR DESCRIPTION
The Java SDK integration test script requires ubuntu-20.04 vm image

Signed-off-by: James Taylor <jamest@uk.ibm.com>