### PR TITLE
Remove indirect upgrade test

### DIFF
--- a/ci/azure-pipelines-daily.yml
+++ b/ci/azure-pipelines-daily.yml
@@ -112,22 +112,6 @@ stages:
               testResultsFormat: 'JUnit'
               testResultsFiles: 'regression/**/results*.xml'
 
-  - stage: Upgrade2_2
-    dependsOn: []
-    displayName: Upgrade Network
-    pool:
-      vmImage: ubuntu-18.04
-    jobs:
-      - job: Upgrade2_2
-        displayName: Run Scenario
-        steps:
-          - checkout: self
-            path: 'go/src/github.com/hyperledger/fabric-test'
-            displayName: Checkout Fabric Test Code
-          - template: templates/install_deps.yml
-          - script: make upgrade2.2
-            displayName: Run Test
-
   - stage: Upgrade1_4to2_2
     dependsOn: []
     displayName: Upgrade Network From 1.4 Directly to 2.2


### PR DESCRIPTION
The indirect upgrade test (v1.4 to v2.0 to v2.2) does not work with Go 1.16
since it steps through release-2.0 which does not
work with Go 1.16.
This commit stops running the test on the environment that
was recently updated to Go 1.16.

There is still a direct upgrade test from v1.4 to v2.2 which works.
This is the recommended path for users (LTS release to LTS release).

Signed-off-by: David Enyeart <enyeart@us.ibm.com>