### PR TITLE
Fix java samplecc build error

### DIFF
--- a/chaincodes/samplecc/java/build.gradle
+++ b/chaincodes/samplecc/java/build.gradle
@@ -13,9 +13,7 @@ sourceCompatibility = 1.8
 repositories {
     mavenLocal()
     mavenCentral()
-    maven() {
-        url "https://repository.mulesoft.org/nexus/content/repositories/public/"
-    }
+    maven { url 'https://jitpack.io' }
 }
 dependencies {
     compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '1.+'


### PR DESCRIPTION
Fabric-Test-Interop builds are failing when installing Java samplecc

The samplecc chaincode has the wrong maven repository url

Signed-off-by: James Taylor <jamest@uk.ibm.com>