### PR TITLE
Revert "Update to latest patch of Node12 (backport #340)"

### DIFF
--- a/ci/azure-pipelines-daily.yml
+++ b/ci/azure-pipelines-daily.yml
@@ -22,7 +22,7 @@ variables:
   GO_BIN: $(Agent.BuildDirectory)/go/bin
   GO_PATH: $(Agent.BuildDirectory)/go
   GO_VER: 1.16.7
-  NODE_VER: 12.22.6
+  NODE_VER: 12.15.0
   PATH: $(Agent.BuildDirectory)/go/bin:$(Agent.BuildDirectory)/go/src/github.com/hyperledger/fabric-test/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 
 stages:

--- a/ci/azure-pipelines-interop.yml
+++ b/ci/azure-pipelines-interop.yml
@@ -31,7 +31,7 @@ variables:
   - name: GO_VER
     value: 1.16.7
   - name: NODE_VER
-    value: 12.22.6
+    value: 12.15.0
   - name: PATH
     value: $(Agent.BuildDirectory)/go/bin:$(Agent.BuildDirectory)/go/src/github.com/hyperledger/fabric-test/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
   - name: RELEASE

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -24,7 +24,7 @@ variables:
   GO_BIN: $(Agent.BuildDirectory)/go/bin
   GO_PATH: $(Agent.BuildDirectory)/go
   GO_VER: 1.16.7
-  NODE_VER: 12.22.6
+  NODE_VER: 12.15.0
   PATH: $(Agent.BuildDirectory)/go/bin:$(Agent.BuildDirectory)/go/src/github.com/hyperledger/fabric-test/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 stages:
   - stage: TestPullRequest


### PR DESCRIPTION
Reverts hyperledger/fabric-test#342

main branch hasn't been updated for node version in fabric-chaincode-node yet, therefore need to revert this change.