### PR TITLE
Add an operator based network for chaos testing

### DIFF
--- a/regression/testdata/chaos-network-spec.yml
+++ b/regression/testdata/chaos-network-spec.yml
@@ -1,0 +1,88 @@
+#! Copyright IBM Corp. All Rights Reserved.
+#!
+#! SPDX-License-Identifier: Apache-2.0
+
+---
+dockerOrg: hyperledger-fabric.jfrog.io
+dockerTag: amd64-latest
+
+#! peer database ledger type (couchdb, goleveldb)
+dbType: goleveldb
+#! This parameter is used to define fabric logging spec in peers
+peerFabricLoggingSpec: info
+#! This parameter is used to define fabric logging spec in orderers
+ordererFabricLoggingSpec: info
+#! tls in the network (true, false or mutual(mutualtls))
+tls: true
+#! fabric metrics with prometheus (true/false)
+metrics: false
+#! true - enable gossip and dynamic leader election
+#! false - disable gossip and set all peers as org leaders
+gossipEnable: false
+#! enable node ou's in fabric network (true/false)
+enableNodeOUs: true
+#! For smoke test suite, crypto-config, connection-profile and channel-artifacts are stored
+#! in smoke directory
+artifactsLocation: .
+
+#! Orderer Config Settings
+orderer:
+  #! Consensus type
+  ordererType: etcdraft
+  batchSize:
+    maxMessageCount: 100
+    absoluteMaxBytes: 10 MB
+    preferredMaxBytes: 2 MB
+  batchTimeOut: 2s
+  #! Etcd raft options and this will be used when ordererType is
+  #! selected as etcdraft
+  etcdraftOptions:
+    tickInterval: 500ms
+    electionTick: 100
+    heartbeatTick: 10
+    maxInflightBlocks: 5
+    snapshotIntervalSize: 100 MB
+
+#! Not being used for smoke test suite
+#! Number of kafka and zookeeper to be launched in network
+#! when ordererType is kafka
+kafka:
+  numKafka: 5
+  #! number of kafka replications for each channel
+  numKafkaReplications: 3
+  numZookeepers: 3
+
+ordererOrganizations:
+  - name: ordererorg1
+    mspId: OrdererOrgExampleCom
+    numOrderers: 5
+    numCa: 1
+
+peerOrganizations:
+  - name: org1
+    mspId: Org1ExampleCom
+    numPeers: 2
+    numCa: 1
+
+  - name: org2
+    mspId: Org2ExampleCom
+    numPeers: 2
+    numCa: 1
+
+  - name: org3
+    mspId: Org3ExampleCom
+    numPeers: 2
+    numCa: 1
+
+#! Capabilites for Orderer, Channel, Application groups
+ordererCapabilities: V2_0
+
+channelCapabilities: V2_0
+
+applicationCapabilities: V2_0
+
+#! Create the channel creation transactions; every org will be included in every channel
+#! This used testorgschannel as the prefix and channels are used like testorgschannel0,
+#! testorgschannel1.... based on number of channels passed
+#! (note: client will need to submit the transactions to create channels)
+numChannels: 1

--- a/regression/testdata/chaos-test-input.yml
+++ b/regression/testdata/chaos-test-input.yml
@@ -1,0 +1,79 @@
+organizations:
+  - name: org1
+    connProfilePath: ./connection-profile
+  - name: org2
+    connProfilePath: ./connection-profile
+  - name: org3
+    connProfilePath: ./connection-profile
+
+createChannel:
+  - channelPrefix: testorgschannel
+    sdk: cli
+    numChannels: 1
+    channelTxPath: ./channel-artifacts/
+    organizations: org1,org2,org3
+
+joinChannel:
+# joins all peers in listed organziations to all channels based on channelPrefix and numChannels
+  - channelPrefix: testorgschannel
+    numChannels: 1
+    organizations: org1,org2,org3
+
+anchorPeerUpdate:
+  - channelName: testorgschannel0
+    organizations: org1
+    anchorPeerUpdateTxPath: ./channel-artifacts/testorgschannel0org1anchor.tx
+  - channelName: testorgschannel0
+    organizations: org2
+    anchorPeerUpdateTxPath: ./channel-artifacts/testorgschannel0org2anchor.tx
+  - channelName: testorgschannel0
+    organizations: org3
+    anchorPeerUpdateTxPath: ./channel-artifacts/testorgschannel0org3anchor.tx
+
+installChaincode:
+# installs chaincode with specified name on all peers in listed organziations
+  - name: basic
+    version: 1.0
+    sdk: cli
+    targetPeers: peer0-org1,peer1-org1
+    path: chaincodes/chaos/node
+    organizations: org1
+    language: node
+    metadataPath: ""
+
+  - name: basic
+    version: 1.0
+    sdk: cli
+    targetPeers: peer0-org2,peer1-org2
+    path: chaincodes/chaos/node
+    organizations: org2
+    language: node
+    metadataPath: ""
+
+  - name: basic
+    version: 1.0
+    sdk: cli
+    targetPeers: peer0-org3,peer1-org3
+    path: chaincodes/chaos/node
+    organizations: org3
+    language: node
+    metadataPath: ""
+
+
+instantiateChaincode:
+  - channelName: testorgschannel0
+    name: basic
+    sdk: cli
+    version: 1.0
+    sequence: 1
+    targetPeers: peer0-org1,peer0-org2,peer0-org3
+    args: ""
+    organizations: org1,org2,org3
+    endorsementPolicy: "OR(AND('Org1ExampleCom.member','Org2ExampleCom.member'),AND('Org1ExampleCom.member','Org3ExampleCom.member'),AND('Org2ExampleCom.member','Org3ExampleCom.member'))"
+    collectionPath: ""
+
+command:
+  - name: docker
+    args:
+      - logs
+      - peer0-org1


### PR DESCRIPTION
This defines a 3 org, 2 peer network that
will be used for chaos testing. It will run
on the daily build so it uses the jfrog images

Signed-off-by: D <d_kelsey@uk.ibm.com>