### PR TITLE
Update pipelines for release-2.4

### DIFF
--- a/ci/azure-pipelines-daily.yml
+++ b/ci/azure-pipelines-daily.yml
@@ -12,9 +12,7 @@ schedules:
     displayName: 'Fabric Test Daily Job'
     branches:
       include:
-        - main
-        - release-2.*
-        - release-1.4
+        - release-2.4
     always: true
 
 variables:

--- a/ci/azure-pipelines-interop.yml
+++ b/ci/azure-pipelines-interop.yml
@@ -11,9 +11,7 @@ schedules:
     displayName: InterOp Testing
     branches:
       include:
-        - main
-        - release-2.3
-        - release-2.2
+        - release-2.4
     always: true
 
 variables:
@@ -21,7 +19,7 @@ variables:
   - name: ARTIFACT_DIRECTORY
     value: $(Pipeline.Workspace)
   - name: BRANCH
-    value: main
+    value: release-2.4
   - name: FABRIC_CFG_PATH
     value: $(Agent.BuildDirectory)/go/src/github.com/hyperledger/fabric-test/config/
   - name: GO_BIN

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -7,14 +7,14 @@ name: $(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.rrr)
 trigger:
   branches:
     include:
-      - main
+      - release-2.4
   paths:
     exclude:
       - tools/chaincode-integration/*
 pr:
   branches:
     include:
-      - main
+      - release-2.4
   paths:
     exclude:
       - tools/chaincode-integration/*

--- a/ci/scripts/interop/publish/docker-images.sh
+++ b/ci/scripts/interop/publish/docker-images.sh
@@ -9,7 +9,4 @@ docker login -u "${ARTIFACTORY_USERNAME}" -p "${ARTIFACTORY_PASSWORD}" hyperledg
 for image in baseos peer orderer ccenv tools ca javaenv nodeenv; do
     docker tag "hyperledger/fabric-${image}" "hyperledger-fabric.jfrog.io/fabric-${image}:amd64-${RELEASE}"
     docker push "hyperledger-fabric.jfrog.io/fabric-${image}:amd64-${RELEASE}"
-
-    docker tag "hyperledger/fabric-${image}" "hyperledger-fabric.jfrog.io/fabric-${image}:amd64-latest"
-    docker push "hyperledger-fabric.jfrog.io/fabric-${image}:amd64-latest"
 done

--- a/ci/scripts/interop/publish/fabric-binary.sh
+++ b/ci/scripts/interop/publish/fabric-binary.sh
@@ -16,8 +16,5 @@ for target in linux-amd64 darwin-amd64; do
     curl -u"${ARTIFACTORY_USERNAME}":"${ARTIFACTORY_PASSWORD}" \
 		  -T "hyperledger-fabric-${target}-${RELEASE}.tar.gz" \
 		  "https://hyperledger.jfrog.io/hyperledger/fabric-binaries/hyperledger-fabric-${target}-${RELEASE}.tar.gz"
-		curl -u"${ARTIFACTORY_USERNAME}":"${ARTIFACTORY_PASSWORD}" \
-		  -T "hyperledger-fabric-${target}-${RELEASE}.tar.gz" \
-		  "https://hyperledger.jfrog.io/hyperledger/fabric-binaries/hyperledger-fabric-${target}-latest.tar.gz"
     popd
 done


### PR DESCRIPTION
After creating release-2.4 branch, update pipelines for release-2.4.
Publish as release-2.4, not latest.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>