### PR TITLE
Update pipelines to use sdk/chaincode release-2.2

### DIFF
--- a/ci/scripts/interop/build/fabric-ca.sh
+++ b/ci/scripts/interop/build/fabric-ca.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
-git clone -b "${BRANCH}" https://github.com/hyperledger/fabric-ca --single-branch "${GOPATH}/src/github.com/hyperledger/fabric-ca"
+git clone -b main https://github.com/hyperledger/fabric-ca --single-branch "${GOPATH}/src/github.com/hyperledger/fabric-ca"
 cd "${GOPATH}/src/github.com/hyperledger/fabric-ca"
 make docker
 

--- a/ci/scripts/interop/build/fabric-chaincode-java.sh
+++ b/ci/scripts/interop/build/fabric-chaincode-java.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
-git clone -b ${BRANCH} https://github.com/hyperledger/fabric-chaincode-java --single-branch "${GOPATH}/src/github.com/hyperledger/fabric-chaincode-java"
+git clone -b release-2.2 https://github.com/hyperledger/fabric-chaincode-java --single-branch "${GOPATH}/src/github.com/hyperledger/fabric-chaincode-java"
 cd "${GOPATH}/src/github.com/hyperledger/fabric-chaincode-java"
 ./gradlew buildImage -x javadoc -x test -x checkstyleMain -x checkstyleTest -x dependencyCheckAnalyze
 

--- a/ci/scripts/interop/build/fabric-chaincode-node.sh
+++ b/ci/scripts/interop/build/fabric-chaincode-node.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
-git clone -b ${BRANCH} https://github.com/hyperledger/fabric-chaincode-node --single-branch "${GOPATH}/src/github.com/hyperledger/fabric-chaincode-node"
+git clone -b release-2.2 https://github.com/hyperledger/fabric-chaincode-node --single-branch "${GOPATH}/src/github.com/hyperledger/fabric-chaincode-node"
 cd "${GOPATH}/src/github.com/hyperledger/fabric-chaincode-node"
 
 # Package source code prior to polluting the directory

--- a/ci/scripts/interop/driver/fabric-sdk-java.sh
+++ b/ci/scripts/interop/driver/fabric-sdk-java.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
-git clone -b "${BRANCH}" https://github.com/hyperledger/fabric-sdk-java --single-branch "${ARTIFACT_DIRECTORY}/fabric-sdk-java"
+git clone -b release-2.2 https://github.com/hyperledger/fabric-sdk-java --single-branch "${ARTIFACT_DIRECTORY}/fabric-sdk-java"
 cd "${ARTIFACT_DIRECTORY}/fabric-sdk-java"
 
 sed -i '/source/d' ./scripts/run-integration-tests.sh

--- a/ci/scripts/interop/driver/fabric-sdk-node.sh
+++ b/ci/scripts/interop/driver/fabric-sdk-node.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
-git clone -b "${BRANCH}" https://github.com/hyperledger/fabric-sdk-node --single-branch "${ARTIFACT_DIRECTORY}/fabric-sdk-node"
+git clone -b release-2.2 https://github.com/hyperledger/fabric-sdk-node --single-branch "${ARTIFACT_DIRECTORY}/fabric-sdk-node"
 cd "${ARTIFACT_DIRECTORY}/fabric-sdk-node"
 
 npm install


### PR DESCRIPTION
The release branches test against the release-2.2 LTS release branch of SDKs/chaincodes,
while main branch tests against main branch of SDKs/chaincodes.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>