### PR TITLE
Back off node version to reflect sdk/chaincode release-2.2 level

### DIFF
--- a/ci/azure-pipelines-daily.yml
+++ b/ci/azure-pipelines-daily.yml
@@ -20,7 +20,7 @@ variables:
   GO_BIN: $(Agent.BuildDirectory)/go/bin
   GO_PATH: $(Agent.BuildDirectory)/go
   GO_VER: 1.16.7
-  NODE_VER: 16.4.0
+  NODE_VER: 12.22.6
   PATH: $(Agent.BuildDirectory)/go/bin:$(Agent.BuildDirectory)/go/src/github.com/hyperledger/fabric-test/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 
 stages:

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -24,7 +24,7 @@ variables:
   GO_BIN: $(Agent.BuildDirectory)/go/bin
   GO_PATH: $(Agent.BuildDirectory)/go
   GO_VER: 1.16.7
-  NODE_VER: 16.4.0
+  NODE_VER: 12.22.6
   PATH: $(Agent.BuildDirectory)/go/bin:$(Agent.BuildDirectory)/go/src/github.com/hyperledger/fabric-test/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 stages:
   - stage: TestPullRequest


### PR DESCRIPTION
Move node version from 16.4.0 to 12.22.6 to reflect release-2.2 sdk/chaincode
that is used with release-2.4 branch testing.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>