### PR TITLE
Back off node version to reflect sdk/chaincode release-2.2 level - Part2

### DIFF
--- a/ci/azure-pipelines-interop.yml
+++ b/ci/azure-pipelines-interop.yml
@@ -29,7 +29,7 @@ variables:
   - name: GO_VER
     value: 1.16.7
   - name: NODE_VER
-    value: 16.4.0
+    value: 12.22.6
   - name: PATH
     value: $(Agent.BuildDirectory)/go/bin:$(Agent.BuildDirectory)/go/src/github.com/hyperledger/fabric-test/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
   - name: RELEASE


### PR DESCRIPTION
Move node version from 16.4.0 to 12.22.6 to reflect release-2.2 sdk/chaincode
that is used with release-2.4 branch testing.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>