### PR TITLE
Update env variables and instructions for post-GOPATH world

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@
 #
 # ------------------------------------------------------------------
 
+# Set PATH for Fabric binaries and FABRIC_CFG_PATH for config
+PATH := $(PATH):$(PWD)/bin
+FABRIC_CFG_PATH := $(PWD)/config
+
 include gotools.mk
 
 regression/barebones_caliper: pre-reqs caliper-init

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ using the Operator tool
 
 While Fabric-Test provides a utility for installing most of its dependencies, you do need a few basic
 tools to get started:
-- Go 1.14 or later
-- Node 1.12.0 or later
+- Go 1.16 or later
+- Node 16 or later
 - Java 8 or later (if using Java chaincode)
 - Docker
 - Docker-Compose
@@ -22,6 +22,15 @@ tools to get started:
 
 Once you've installed these simple dependencies you simply execute `make pre-reqs` from the root of the
 repo and Fabric-Test will bootstrap the rest of the dependencies and install the required NPM packages.
+
+## Environment variables
+
+Make sure `$GOPATH/bin` (if GOPATH is set) or `$HOME/go/bin` is in your `$PATH` so that the go tools can be found.
+
+If you run the `make` targets from the project root directory,
+`fabric-test/bin` with the Fabric binaries will get added to `PATH` and
+`fabric-test/config` with Fabric node config files will get added to `FABRIC_CFG_PATH`.
+If you run the tests directly (outside of `make`) you will need to set these variables yourself.
 
 ## Running Test Suites with Make
 

--- a/gotools.mk
+++ b/gotools.mk
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 GOTOOLS = gocov gocov-xml goimports golint ginkgo govendor
-TOOLS = $(GOPATH)/bin
 
 .PHONY: gotools
 gotools: $(patsubst %,build/tools/%, $(GOTOOLS))
@@ -12,5 +11,5 @@ build/tools/%: tools/gotools/go.mod tools/gotools/tools.go
 	@mkdir -p $(@D)
 	@$(eval TOOL = ${subst build/tools/,,${@}})
 	@$(eval FQP = $(shell grep ${TOOL} tools/gotools/tools.go | cut -d " " -f2 | grep ${TOOL}\"$))
-	@echo Installing ${TOOL} at $(TOOLS) from ${FQP}
-	@cd tools/gotools && GO111MODULE=on GOBIN=$(TOOLS) go install ${FQP}
+	@echo "Installing ${TOOL} from ${FQP} (installs to HOME/go/bin by default if GOPATH is not set)"
+	@cd tools/gotools && go install ${FQP}


### PR DESCRIPTION
Modern Go installations do not use GOPATH.
Update the prereq gotools target to work without GOPATH, GOBIN, GO111MODULE settings.

Also set PATH and FABRIC_CFG_PATH to pick up fabric /bin and /config directories.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>