### PR TITLE
Improve PTE logging when channel is not yet initialized on orderer #372

### DIFF
--- a/tools/PTE/pte-main.js
+++ b/tools/PTE/pte-main.js
@@ -790,6 +790,7 @@ async function createOrUpdateOneChannel(client, channelOrgName) {
                         break
                     } catch (err) {
                         if ( retry < maxWaitForFetchChannelBlock ) {
+                            logger.warn('[createOrUpdateOneChannel] Orderer system channel %s is not yet ready, retrying for genesis block in one second', channelName);
                             await sleep(1000);
                             retry++
                         } else {
@@ -910,6 +911,7 @@ async function joinChannel(channel, client, org) {
                     break
                 } catch (err) {
                     if ( retry < maxWaitForFetchChannelBlock ) {
+                        logger.warn('[joinChannel] Channel %s is not yet ready, retrying for genesis block in one second', channelName);
                         await sleep(1000);
                         retry++
                     } else {


### PR DESCRIPTION
Improve PTE logging when channel is not yet initialized on orderer #372

Signed-off-by: Ketul Shah <shah.ketul@ibm.com>