### PR TITLE
GitHub Actions

### DIFF
--- a/.github/cctesttool-build.yml
+++ b/.github/cctesttool-build.yml
@@ -1,0 +1,28 @@
+name: fabric-chaincode-integration
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x]
+
+    defaults:
+      run:
+        working-directory: ./tools/chaincode-integration
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test 

--- a/.github/cctesttool-publish.yml
+++ b/.github/cctesttool-publish.yml
@@ -1,0 +1,24 @@
+name: Publish package to GitHub Packages
+on:
+  push:
+    branches: [ main ]
+jobs:
+  build:
+    runs-on: ubuntu-latest 
+    permissions: 
+      contents: read
+      packages: write 
+    defaults:
+      run:
+        working-directory: ./tools/chaincode-integration      
+    steps:
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to GitHub Packages
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: 'https://npm.pkg.github.com'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
This is to compile the chaincode test tool and then publish it to the Github npm registry

Context:
The chaincode test tool can be used by any chaincode implementation; an easy way to achieve distribution is to publish this as a npm module to the Github NPM  for this repository. 

Then each chaincode can get fetch the test tool from this standard location.  



Signed-off-by: Matthew B White <whitemat@uk.ibm.com>