### PR TITLE
Bump CouchDB to v3.2

### DIFF
--- a/regression/hsm/docker/docker-compose-test-net.yaml
+++ b/regression/hsm/docker/docker-compose-test-net.yaml
@@ -47,7 +47,7 @@ services:
     environment:
       - COUCHDB_USER=admin
       - COUCHDB_PASSWORD=adminpw
-    image: couchdb:3.1
+    image: couchdb:3.2
     networks:
       test:
 
@@ -101,7 +101,7 @@ services:
     environment:
       - COUCHDB_USER=admin
       - COUCHDB_PASSWORD=adminpw
-    image: couchdb:3.1
+    image: couchdb:3.2
     networks:
       test:
 

--- a/tools/operator/launcher/k8s/extendNetwork.go
+++ b/tools/operator/launcher/k8s/extendNetwork.go
@@ -77,7 +77,7 @@ func (k8s K8s) extendLaunchObject(nsConfig networkspec.Config) ([]LaunchConfig, 
 					container = corev1.Container{
 						Name:            "couchdb",
 						Resources:       k8s.resources(nsConfig.K8s.Resources.Couchdb),
-						Image:           "couchdb:3.1",
+						Image:           "couchdb:3.2",
 						ImagePullPolicy: corev1.PullPolicy("Always"),
 						Env: []corev1.EnvVar{
 							{

--- a/tools/operator/launcher/k8s/network.go
+++ b/tools/operator/launcher/k8s/network.go
@@ -100,7 +100,7 @@ func (k8s K8s) launchObject(nsConfig networkspec.Config) ([]LaunchConfig, error)
 				container = corev1.Container{
 					Name:            "couchdb",
 					Resources:       k8s.resources(nsConfig.K8s.Resources.Couchdb),
-					Image:           "couchdb:3.1",
+					Image:           "couchdb:3.2",
 					ImagePullPolicy: corev1.PullPolicy("Always"),
 					Env: []corev1.EnvVar{
 						{

--- a/tools/operator/templates/docker/docker-compose.yaml
+++ b/tools/operator/templates/docker/docker-compose.yaml
@@ -36,7 +36,7 @@
 #@     for j in range(0, org.numPeers):
 #@       container_name = "couchdb-peer{}-{}".format(j, org.name)
 #@       env = ["COUCHDB_USER=admin", "COUCHDB_PASSWORD=adminpw"]
-#@       services[container_name] = {"container_name":container_name, "environment":env, "image":"couchdb:3.1", "ports":["{}:5984".format(couchDBUniquePort)]}
+#@       services[container_name] = {"container_name":container_name, "environment":env, "image":"couchdb:3.2", "ports":["{}:5984".format(couchDBUniquePort)]}
 #@       couchDBUniquePort += 1
 #@     end
 #@   end

--- a/tools/operator/templates/docker/peer-extend.yaml
+++ b/tools/operator/templates/docker/peer-extend.yaml
@@ -23,7 +23,7 @@
 #@       j = j + config.peerOrganizations[k].numPeers
 #@       container_name = "couchdb-peer{}-{}".format(j, org.name)
 #@       env = ["COUCHDB_USER=admin", "COUCHDB_PASSWORD=adminpw"]
-#@       services[container_name] = {"container_name":container_name, "environment":env, "image":"couchdb:3.1", "ports":["{}:5984".format(couchDBUniquePort)]}
+#@       services[container_name] = {"container_name":container_name, "environment":env, "image":"couchdb:3.2", "ports":["{}:5984".format(couchDBUniquePort)]}
 #@       couchDBUniquePort += 1
 #@     end
 #@     end


### PR DESCRIPTION
Update CouchDB docker images to v3.2.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>