### PR TITLE
Run interop and daily pipelines on supported releases

### DIFF
--- a/ci/azure-pipelines-daily.yml
+++ b/ci/azure-pipelines-daily.yml
@@ -13,8 +13,8 @@ schedules:
     branches:
       include:
         - main
-        - release-2.*
-        - release-1.4
+        - release-2.4
+        - release-2.2
     always: true
 
 variables:

--- a/ci/azure-pipelines-interop.yml
+++ b/ci/azure-pipelines-interop.yml
@@ -13,7 +13,6 @@ schedules:
       include:
         - main
         - release-2.4
-        - release-2.3
         - release-2.2
     always: true
 


### PR DESCRIPTION
Only run interop and daily pipelines on:
        - main
        - release-2.4
        - release-2.2

Signed-off-by: David Enyeart <enyeart@us.ibm.com>