### PR TITLE
Disable daily test for release-2.3

### DIFF
--- a/ci/azure-pipelines-daily.yml
+++ b/ci/azure-pipelines-daily.yml
@@ -6,14 +6,6 @@
 name: Fabric-Test-Daily-$(Date:yyyyMMdd)
 trigger: none
 pr: none
-schedules:
-  # 3 AM UTC/10 PM EST
-  - cron: "0 3 * * *"
-    displayName: 'Fabric Test Daily Job'
-    branches:
-      include:
-        - release-2.3
-    always: true
 
 variables:
   FABRIC_CFG_PATH: $(Agent.BuildDirectory)/go/src/github.com/hyperledger/fabric-test/config/


### PR DESCRIPTION
release-2.3 will not be updated to Go 1.18, therefore disable
the test to suppress failures related to Go 1.18.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>