### PR TITLE
Bump chaincode integration tool version to 0.6.0

### DIFF
--- a/tools/chaincode-integration/README.md
+++ b/tools/chaincode-integration/README.md
@@ -43,8 +43,8 @@ The tool itself has been tested with Node16; over and above this you will need:
 The tool is intended to be provided as an NPM module. Until release you can install it as follows:
 
 ```
-curl -L https://raw.githubusercontent.com/hyperledger/fabric-test/main/tools/chaincode-integration/fabric-chaincode-integration-0.5.0.tgz
-npm init -y && npm install -s fabric-chaincode-integration-0.5.0.tgz
+curl -L https://raw.githubusercontent.com/hyperledger/fabric-test/main/tools/chaincode-integration/fabric-chaincode-integration-0.6.0.tgz
+npm init -y && npm install -s fabric-chaincode-integration-0.6.0.tgz
 ```
 
 Check that the tool is working by getting the help text
@@ -72,7 +72,7 @@ The default action is to run the tests, reading the cucumber-js config file `cuc
 
 On first usage, run `$(npm bin)/fabric-chaincode-integration init` to copy to the current directory the configuration file `cucumber.js`. It is required that the `cucumber.js` file will be updated. 
 
-Update the configuration, and then rerun the same command. This will run the default set of tags `@basic-checks or @advanced-types or @metadata-checks`
+Update the configuration, and then rerun the same command. This will run the default set of tags `@basic-checks or @advanced-types or @metadata-checks or @ccaas`
 To change which tags are used, set environment variable `SCENARIO_TAGS`. You can limit which of these are run by specifying a [cucumber tag expression](https://cucumber.io/docs/cucumber/api/#tag-expressions). Check the list of tests for the tags available.
 
 

--- a/tools/chaincode-integration/package-lock.json
+++ b/tools/chaincode-integration/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperledger/fabric-chaincode-integration",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperledger/fabric-chaincode-integration",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cucumber/cucumber": "^7.3.2",

--- a/tools/chaincode-integration/package.json
+++ b/tools/chaincode-integration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/fabric-chaincode-integration",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A tool for testing fabric chaincode implementations",
   "bin": {
     "fabric-chaincode-integration": "dist/run.js"

--- a/tools/chaincode-integration/src/run.ts
+++ b/tools/chaincode-integration/src/run.ts
@@ -44,7 +44,7 @@ yargs
                 .option('t', {
                     alias: 'tags',
                     describe: 'tags defined in the feature files',
-                    default: '@basic-checks or @advanced-types or @metadata-checks',
+                    default: '@basic-checks or @advanced-types or @metadata-checks or @ccaas',
                 });
         },
         async (argv: any) => {


### PR DESCRIPTION
Also updates default tags to run

Signed-off-by: James Taylor <jamest@uk.ibm.com>