### PR TITLE
fabric-test main branch should push images as '3.0-stable'

### DIFF
--- a/ci/azure-pipelines-daily.yml
+++ b/ci/azure-pipelines-daily.yml
@@ -13,6 +13,7 @@ schedules:
     branches:
       include:
         - main
+        - release-2.5
         - release-2.4
         - release-2.2
     always: true

--- a/ci/azure-pipelines-interop.yml
+++ b/ci/azure-pipelines-interop.yml
@@ -12,6 +12,7 @@ schedules:
     branches:
       include:
         - main
+        - release-2.5
         - release-2.4
         - release-2.2
     always: true
@@ -35,7 +36,7 @@ variables:
   - name: PATH
     value: $(Agent.BuildDirectory)/go/bin:$(Agent.BuildDirectory)/go/src/github.com/hyperledger/fabric-test/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
   - name: RELEASE
-    value: 2.5-stable
+    value: 3.0-stable
   - name: WORKING_DIRECTORY
     value: $(System.DefaultWorkingDirectory)
 


### PR DESCRIPTION
fabric-test main branch should push images to jfrog as '3.0-stable'. fabric-test release-2.5 branch will start pushing as '2.5-stable'.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>