### PR TITLE
Setup release-2.5 environment variables

### DIFF
--- a/ci/azure-pipelines-daily.yml
+++ b/ci/azure-pipelines-daily.yml
@@ -12,7 +12,7 @@ schedules:
     displayName: 'Fabric Test Daily Job'
     branches:
       include:
-        - release-2.4
+        - release-2.5
     always: true
 
 variables:

--- a/ci/azure-pipelines-interop.yml
+++ b/ci/azure-pipelines-interop.yml
@@ -11,7 +11,7 @@ schedules:
     displayName: InterOp Testing
     branches:
       include:
-        - release-2.4
+        - release-2.5
     always: true
 
 variables:
@@ -19,7 +19,7 @@ variables:
   - name: ARTIFACT_DIRECTORY
     value: $(Pipeline.Workspace)
   - name: BRANCH
-    value: release-2.4
+    value: release-2.5
   - name: FABRIC_CFG_PATH
     value: $(Agent.BuildDirectory)/go/src/github.com/hyperledger/fabric-test/config/
   - name: GO_BIN
@@ -33,7 +33,7 @@ variables:
   - name: PATH
     value: $(Agent.BuildDirectory)/go/bin:$(Agent.BuildDirectory)/go/src/github.com/hyperledger/fabric-test/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
   - name: RELEASE
-    value: 2.4-stable
+    value: 2.5-stable
   - name: WORKING_DIRECTORY
     value: $(System.DefaultWorkingDirectory)
 

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -7,14 +7,14 @@ name: $(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.rrr)
 trigger:
   branches:
     include:
-      - release-2.4
+      - release-2.5
   paths:
     exclude:
       - tools/chaincode-integration/*
 pr:
   branches:
     include:
-      - release-2.4
+      - release-2.5
   paths:
     exclude:
       - tools/chaincode-integration/*


### PR DESCRIPTION
Update BRANCH to release-2.5 to pull from Fabric release-2.5.
Update RELEASE to 2.5-stable to push to jfrog as 2.5-stable.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>