### PR TITLE
Revert TestNodeChaincode to Node version 12.22.6

### DIFF
--- a/ci/azure-pipelines-interop.yml
+++ b/ci/azure-pipelines-interop.yml
@@ -28,7 +28,7 @@ variables:
     value: $(Agent.BuildDirectory)/go
   - name: GO_VER
     value: 1.18.2
-  - name: NODE_VER
+  - name: NODE_VER # OVERRIDE NODE VERSION IN TestNodeChaincode JOB (BELOW) IN RELEASE-2.2 SINCE NODE CHAINCODE V2.2 DOESN'T SUPPORT MORE RECENT NODE VERSIONS
     value: 16.17.0
   - name: PATH
     value: $(Agent.BuildDirectory)/go/bin:$(Agent.BuildDirectory)/go/src/github.com/hyperledger/fabric-test/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
@@ -157,6 +157,9 @@ stages:
       - job: TestNodeChaincode
         pool:
           vmImage: ubuntu-18.04
+        variables:
+          - name: NODE_VER # OVERRIDE NODE VERSION IN RELEASE-2.2 SINCE NODE CHAINCODE V2.2 DOESN'T SUPPORT MORE RECENT NODE VERSIONS
+            value: 12.22.6
         steps:
           - download: current
             patterns: '*-docker.tgz'


### PR DESCRIPTION
Revert TestNodeChaincode to Node version 12.22.6
since node chaincode doesn't support more recent node versions in v2.2.x.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>