### PR TITLE
Fix interop job publishing (main)

### DIFF
--- a/ci/scripts/interop/publish/fabric-ca-binary.sh
+++ b/ci/scripts/interop/publish/fabric-ca-binary.sh
@@ -9,7 +9,8 @@ cd "${GOPATH}/src/github.com/hyperledger/fabric-ca"
 cp "${ARTIFACT_DIRECTORY}/ca-source/ca-source.tgz" .
 tar -xzf ca-source.tgz
 
-for target in linux-amd64 darwin-amd64; do
+# Until cross-compiling gets fixed, just build on linux-amd64 for now
+for target in linux-amd64; do
 	make "release/${target}"
 	pushd "release/${target}"
 	tar -czvf "hyperledger-fabric-ca-${target}-${RELEASE}.tar.gz" bin

--- a/scripts/pullBinaries.sh
+++ b/scripts/pullBinaries.sh
@@ -28,7 +28,9 @@ printf "\nDownloading fabric-%s binaries from Artifactory\n" "${ARCH}"
 REPOS=("$@")
 mkdir -p "${WD}/bin"
 for repo in "${REPOS[@]}"; do
-	ARTIFACTORY_URL=https://hyperledger.jfrog.io/hyperledger/fabric-binaries/hyperledger-${repo}-${ARCH}-${RELEASE_VERSION}.tar.gz
+	#Temporarily pull from '2.5-stable' instead of 'latest'
+	#ARTIFACTORY_URL=https://hyperledger.jfrog.io/hyperledger/fabric-binaries/hyperledger-${repo}-${ARCH}-${RELEASE_VERSION}.tar.gz
+	ARTIFACTORY_URL=https://hyperledger.jfrog.io/hyperledger/fabric-binaries/hyperledger-${repo}-${ARCH}-2.5-stable.tar.gz
 	curl -sS "${ARTIFACTORY_URL}" -o binaries.tgz
 	tar -xf binaries.tgz
 	rm -rf binaries.tgz


### PR DESCRIPTION
1. Don't build fabric-ca darwin binaries due to cross-compiling issues

2. Temporarily pull binaries from '2.5-stable' instead of 'latest' to get things working again. Later we'll switch the function tests to build instead of pull binaries.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>