### PR TITLE
Revert temp pulling of binaries from 2.5-stable (main)

### DIFF
--- a/scripts/pullBinaries.sh
+++ b/scripts/pullBinaries.sh
@@ -28,9 +28,7 @@ printf "\nDownloading fabric-%s binaries from Artifactory\n" "${ARCH}"
 REPOS=("$@")
 mkdir -p "${WD}/bin"
 for repo in "${REPOS[@]}"; do
-	#Temporarily pull from '2.5-stable' instead of 'latest'
-	#ARTIFACTORY_URL=https://hyperledger.jfrog.io/hyperledger/fabric-binaries/hyperledger-${repo}-${ARCH}-${RELEASE_VERSION}.tar.gz
-	ARTIFACTORY_URL=https://hyperledger.jfrog.io/hyperledger/fabric-binaries/hyperledger-${repo}-${ARCH}-2.5-stable.tar.gz
+	ARTIFACTORY_URL=https://hyperledger.jfrog.io/hyperledger/fabric-binaries/hyperledger-${repo}-${ARCH}-${RELEASE_VERSION}.tar.gz
 	curl -sS "${ARTIFACTORY_URL}" -o binaries.tgz
 	tar -xf binaries.tgz
 	rm -rf binaries.tgz


### PR DESCRIPTION
Pull binaries from jfrog 'latest' instead of '2.5-stable' in main branch

Signed-off-by: David Enyeart <enyeart@us.ibm.com>