### PR TITLE
Bump alpine 3.16 (release-2.4)

### DIFF
--- a/images/ca/Dockerfile
+++ b/images/ca/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-ARG ALPINE_VER=3.14
+ARG ALPINE_VER=3.16
 ARG BRANCH="main"
 ARG GO_LDFLAGS=-"linkmode external -extldflags '-lpthread'"
 ARG GO_TAGS=pkcs11

--- a/images/orderer/Dockerfile
+++ b/images/orderer/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG ALPINE_VER=3.14
+ARG ALPINE_VER=3.16
 ARG BRANCH=release-2.4
 ARG GO_TAGS=pkcs11
 ARG GO_VER=1.18.2

--- a/images/peer/Dockerfile
+++ b/images/peer/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG ALPINE_VER=3.14
+ARG ALPINE_VER=3.16
 ARG BRANCH=release-2.4
 ARG GO_TAGS=pkcs11
 ARG GO_VER=1.18.2

--- a/images/proxy-tools/Dockerfile
+++ b/images/proxy-tools/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-ARG ALPINE_VER=3.14
+ARG ALPINE_VER=3.16
 ARG FABRIC_BRANCH="release-2.4"
 ARG FABRIC_CA_BRANCH="main"
 ARG GO_LDFLAGS=-"linkmode external -extldflags '-lpthread'"

--- a/images/proxy/Dockerfile
+++ b/images/proxy/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ARG SOFTHSM_VERSION=2.6.1
 
-FROM alpine:3.14
+FROM alpine:3.16
 
 ARG SOFTHSM_VERSION
 


### PR DESCRIPTION
Signed-off-by: David Enyeart <enyeart@us.ibm.com>