### PR TITLE
Revert Alpine to 3.14 for HSM tests

### DIFF
--- a/images/ca/Dockerfile
+++ b/images/ca/Dockerfile
@@ -1,11 +1,15 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-ARG ALPINE_VER=3.16
+
+# NOTE - 1.18.2-alpine3.14 is the last version we can build pkcs11 on without changes.
+# Need to investigate what is needed to move up to later Alpine versions.
+# Go 1.18.2 is latest Go version available on Alpine 3.14 images.
+ARG ALPINE_VER=3.14
 ARG BRANCH="main"
 ARG GO_LDFLAGS=-"linkmode external -extldflags '-lpthread'"
 ARG GO_TAGS=pkcs11
-ARG GO_VER=1.18.7
+ARG GO_VER=1.18.2
 ARG PROXY_VERSION=2032875
 
 FROM golang:${GO_VER}-alpine${ALPINE_VER} as ca-builder

--- a/images/orderer/Dockerfile
+++ b/images/orderer/Dockerfile
@@ -2,10 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG ALPINE_VER=3.16
+# NOTE - 1.18.2-alpine3.14 is the last version we can build pkcs11 on without changes.
+# Need to investigate what is needed to move up to later Alpine versions.
+# Go 1.18.2 is latest Go version available on Alpine 3.14 images.
+ARG ALPINE_VER=3.14
 ARG BRANCH=main
 ARG GO_TAGS=pkcs11
-ARG GO_VER=1.18.7
+ARG GO_VER=1.18.2
 ARG PROXY_VERSION=2032875
 
 FROM golang:${GO_VER}-alpine${ALPINE_VER} as orderer-builder

--- a/images/peer/Dockerfile
+++ b/images/peer/Dockerfile
@@ -2,10 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG ALPINE_VER=3.16
+# NOTE - 1.18.2-alpine3.14 is the last version we can build pkcs11 on without changes.
+# Need to investigate what is needed to move up to later Alpine versions.
+# Go 1.18.2 is latest Go version available on Alpine 3.14 images.
+ARG ALPINE_VER=3.14
 ARG BRANCH=main
 ARG GO_TAGS=pkcs11
-ARG GO_VER=1.18.7
+ARG GO_VER=1.18.2
 ARG PROXY_VERSION=2032875
 
 FROM golang:${GO_VER}-alpine${ALPINE_VER} as peer-builder

--- a/images/proxy-tools/Dockerfile
+++ b/images/proxy-tools/Dockerfile
@@ -1,12 +1,16 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-ARG ALPINE_VER=3.16
+
+# NOTE - 1.18.2-alpine3.14 is the last version we can build pkcs11 on without changes.
+# Need to investigate what is needed to move up to later Alpine versions.
+# Go 1.18.2 is latest Go version available on Alpine 3.14 images.
+ARG ALPINE_VER=3.14
 ARG FABRIC_BRANCH="main"
 ARG FABRIC_CA_BRANCH="main"
 ARG GO_LDFLAGS=-"linkmode external -extldflags '-lpthread'"
 ARG GO_TAGS=pkcs11
-ARG GO_VER=1.18.7
+ARG GO_VER=1.18.2
 ARG PROXY_VERSION=2032875
 
 FROM golang:${GO_VER}-alpine${ALPINE_VER} as ca-builder

--- a/images/proxy/Dockerfile
+++ b/images/proxy/Dockerfile
@@ -3,7 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 ARG SOFTHSM_VERSION=2.6.1
 
-FROM alpine:3.16
+# NOTE - 1.18.2-alpine3.14 is the last version we can build pkcs11 on without changes.
+# Need to investigate what is needed to move up to later Alpine versions.
+# Go 1.18.2 is latest Go version available on Alpine 3.14 images.
+
+FROM alpine:3.14
 
 ARG SOFTHSM_VERSION
 


### PR DESCRIPTION
pkcs11 not compiling on Alpine 3.16. Revert the HSM tests to 3.14.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>