### PR TITLE
Update java and node chaincode to release-2.5

### DIFF
--- a/ci/scripts/interop/build/fabric-chaincode-java.sh
+++ b/ci/scripts/interop/build/fabric-chaincode-java.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
-git clone -b release-2.4 https://github.com/hyperledger/fabric-chaincode-java --single-branch "${GOPATH}/src/github.com/hyperledger/fabric-chaincode-java"
+git clone -b release-2.5 https://github.com/hyperledger/fabric-chaincode-java --single-branch "${GOPATH}/src/github.com/hyperledger/fabric-chaincode-java"
 cd "${GOPATH}/src/github.com/hyperledger/fabric-chaincode-java"
 ./gradlew buildImage -x javadoc -x test -x checkstyleMain -x checkstyleTest -x dependencyCheckAnalyze
 

--- a/ci/scripts/interop/build/fabric-chaincode-node.sh
+++ b/ci/scripts/interop/build/fabric-chaincode-node.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
-git clone -b release-2.4 https://github.com/hyperledger/fabric-chaincode-node --single-branch "${GOPATH}/src/github.com/hyperledger/fabric-chaincode-node"
+git clone -b release-2.5 https://github.com/hyperledger/fabric-chaincode-node --single-branch "${GOPATH}/src/github.com/hyperledger/fabric-chaincode-node"
 cd "${GOPATH}/src/github.com/hyperledger/fabric-chaincode-node"
 
 # Package source code prior to polluting the directory


### PR DESCRIPTION
Update java and node chaincode to release-2.5.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>